### PR TITLE
[Do Not Merge] Refactoring plone client to use axios instead of superagent

### DIFF
--- a/news/19.internal 
+++ b/news/19.internal 
@@ -1,0 +1,1 @@
+Refactoring plone client to use axios instead of superagent @hemant-hc

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "4.29.1",
-    "superagent": "8.0.9",
+    "axios": "^1.4.0",
     "universal-cookie": "^4.0.4",
     "zod": "^3.21.4"
   },

--- a/src/API.ts
+++ b/src/API.ts
@@ -18,7 +18,7 @@ function getBackendURL(apiPath: string, path: string) {
 
   if (path.startsWith('http://') || path.startsWith('https://')) return path;
 
-  const adjustedPath = path[0] !== '/' ? `\/${path}` : path;
+  const adjustedPath = path[0] !== '/' ? `/${path}` : path;
 
   return `${apiPath}${APISUFIX}${adjustedPath}`;
 }

--- a/src/API.ts
+++ b/src/API.ts
@@ -1,6 +1,5 @@
-import superagent from 'superagent';
+import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
 import Cookies from 'universal-cookie';
-import type request from 'superagent';
 import { PloneClientConfig } from './interfaces/config';
 
 const methods = ['get', 'post', 'put', 'patch', 'delete'];
@@ -19,7 +18,7 @@ function getBackendURL(apiPath: string, path: string) {
 
   if (path.startsWith('http://') || path.startsWith('https://')) return path;
 
-  const adjustedPath = path[0] !== '/' ? `/${path}` : path;
+  const adjustedPath = path[0] !== '/' ? `\/${path}` : path;
 
   return `${apiPath}${APISUFIX}${adjustedPath}`;
 }
@@ -32,17 +31,21 @@ export async function handleRequest(
   const fetcher = new API();
   const response = await fetcher[method](path, options);
 
-  if (!response.ok) {
+  /*
+  3xx (redirect), 4xx, 5xx http status codes would indicate an error for the
+  API.
+  */
+  if (!response || ![200, 201, 204].includes(response.status)) {
     throw new Error('Network response was not ok');
   }
-  return response.body;
+  return response.data;
 }
 
 export default class API {
   [m: string]: (
     path: string,
     options: ApiRequestParams,
-  ) => Promise<request.Response>;
+  ) => Promise<AxiosResponse<any>>;
 
   constructor(req?: Request) {
     const cookies = new Cookies();
@@ -59,67 +62,45 @@ export default class API {
           checkUrl = false,
         }: ApiRequestParams,
       ) => {
-        let request: request.SuperAgentRequest;
+        const requestOptions: AxiosRequestConfig = {
+          url: getBackendURL(config.apiPath, path),
+          method,
+          params,
+          data,
+          headers: {
+            Accept: 'application/json',
+            ...headers,
+          },
+        };
 
-        // @ts-ignore
-        request = superagent[method](getBackendURL(config.apiPath, path));
-
-        if (params) {
-          request.query(params);
-        }
         // let authToken;
+        // const axiosInstance = axios.create();
         // if (req) {
         //   // @ts-ignore
         //   // We are in SSR
         //   authToken = req.universalCookies.get('auth_token');
-        //   request.use(addHeadersFactory(req));
+        //   axiosInstance.interceptors.request.use(
+        //     addHeadersFactory(requestOptions),
+        //   );
         // } else {
         //   authToken = cookies.get('auth_token');
         // }
 
-        if (config.token) {
-          request.set('Authorization', `Bearer ${config.token}`);
+        if (config.token && requestOptions.headers) {
+          requestOptions.headers['Authorization'] = `Bearer ${config.token}`;
         }
 
-        request.set('Accept', 'application/json');
-
-        if (type) {
-          request.type(type);
+        if (type && requestOptions.headers) {
+          requestOptions.headers['Content-Type'] = type;
         }
 
-        Object.keys(headers).forEach((key) => request.set(key, headers[key]));
+        try {
+          const response = await axios(requestOptions);
 
-        if (data) {
-          request.send(data);
+          return response;
+        } catch (error) {
+          throw error as Error;
         }
-
-        return request;
-
-        // request.end((err, response) => {
-        //   if (
-        //     checkUrl &&
-        //     request.url &&
-        //     request.xhr &&
-        //     stripQuerystring(request.url) !==
-        //       stripQuerystring(request.xhr.responseURL)
-        //   ) {
-        //     if (request.xhr.responseURL?.length === 0) {
-        //       return reject({
-        //         code: 408,
-        //         status: 408,
-        //         url: request.xhr.responseURL,
-        //       });
-        //     }
-        //     return reject({
-        //       code: 301,
-        //       url: request.xhr.responseURL,
-        //     });
-        //   }
-        //   return err ? reject(err) : resolve(response.body || response.text);
-        // });
-
-        // promise.request = request;
-        // return promise;
       };
     });
   }

--- a/src/resetFixture.ts
+++ b/src/resetFixture.ts
@@ -1,23 +1,39 @@
-import superagent from 'superagent';
+import axios from 'axios';
 
 export async function setup() {
   const APIPATH = 'http://localhost:55001/plone';
   const data =
     '<?xml version="1.0"?><methodCall><methodName>run_keyword</methodName><params><param><value><string>remote_zodb_setup</string></value></param><param><value><array><data><value><string>plone.app.robotframework.testing.PLONE_ROBOT_TESTING</string></value></data></array></value></param></params></methodCall>';
-  const request = superagent.post(`${APIPATH}/RobotRemote`);
-  request.accept('text/xml');
-  request.set('content-type', 'text/xml');
-  request.send(data);
-  return await request;
+
+  try {
+    const response = await axios.post(`${APIPATH}/RobotRemote`, data, {
+      headers: {
+        Accept: 'text/xml',
+        'Content-Type': 'text/xml',
+      },
+    });
+
+    return response;
+  } catch (error) {
+    throw error as Error;
+  }
 }
 
 export async function teardown() {
   const APIPATH = 'http://localhost:55001/plone';
   const data =
     '<?xml version="1.0"?><methodCall><methodName>run_keyword</methodName><params><param><value><string>remote_zodb_teardown</string></value></param><param><value><array><data><value><string>plone.app.robotframework.testing.PLONE_ROBOT_TESTING</string></value></data></array></value></param></params></methodCall>';
-  const request = superagent.post(`${APIPATH}/RobotRemote`);
-  request.accept('text/xml');
-  request.set('content-type', 'text/xml');
-  request.send(data);
-  return await request;
+
+  try {
+    const response = await axios.post(`${APIPATH}/RobotRemote`, data, {
+      headers: {
+        Accept: 'text/xml',
+        'Content-Type': 'text/xml',
+      },
+    });
+
+    return response;
+  } catch (error) {
+    throw error as Error;
+  }
 }

--- a/src/restapi/breadcrumbs/get.test.tsx
+++ b/src/restapi/breadcrumbs/get.test.tsx
@@ -36,8 +36,6 @@ describe('[GET] Breadcrumbs', () => {
 
     await waitFor(() => expect(result.current.isError).toBe(true));
 
-    // @ts-ignore
-    expect(result.current.error.status).toBe(404);
     expect(result.current.error).toBeDefined();
   });
 });

--- a/src/restapi/breadcrumbs/get.test.tsx
+++ b/src/restapi/breadcrumbs/get.test.tsx
@@ -37,5 +37,7 @@ describe('[GET] Breadcrumbs', () => {
     await waitFor(() => expect(result.current.isError).toBe(true));
 
     expect(result.current.error).toBeDefined();
+    // @ts-expect-error TODO: find a way to set the error type properly for error
+    expect(result.current.error.response?.status).toBe(404);
   });
 });

--- a/src/restapi/content/add.test.tsx
+++ b/src/restapi/content/add.test.tsx
@@ -34,9 +34,7 @@ describe('[POST] Content', () => {
       wrapper: createWrapper(),
     });
 
-    act(() => {
-      result.current.mutate({ path, data });
-    });
+    await act(() => result.current.mutateAsync({ path, data }));
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
@@ -57,9 +55,7 @@ describe('[POST] Content', () => {
       wrapper: createWrapper(),
     });
 
-    act(() => {
-      result.current.mutate({ path, data });
-    });
+    await act(() => result.current.mutateAsync({ path, data }));
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
@@ -79,14 +75,15 @@ describe('[POST] Content', () => {
       wrapper: createWrapper(),
     });
 
-    act(() => {
-      result.current.mutate({ path, data });
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({ path, data });
+      } catch (error) {
+        // We expect an error, so do nothing
+      }
     });
 
-    await waitFor(() => expect(result.current.isError).toBe(true));
-
-    // @ts-ignore
-    expect(result.current.error.status).toBe(404);
+    expect(result.current.status).toBe('error');
     expect(result.current.error).toBeDefined();
   });
 });

--- a/src/restapi/content/add.test.tsx
+++ b/src/restapi/content/add.test.tsx
@@ -85,5 +85,7 @@ describe('[POST] Content', () => {
 
     expect(result.current.status).toBe('error');
     expect(result.current.error).toBeDefined();
+    // @ts-expect-error TODO: find a way to set the error type properly for error
+    expect(result.current.error.response?.status).toBe(404);
   });
 });

--- a/src/restapi/content/delete.test.tsx
+++ b/src/restapi/content/delete.test.tsx
@@ -37,9 +37,7 @@ describe('[DELETE] Content', () => {
       wrapper: createWrapper(),
     });
 
-    act(() => {
-      result.current.mutate({ path: pagePath });
-    });
+    await act(() => result.current.mutateAsync({ path: pagePath }));
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
   });
@@ -51,10 +49,18 @@ describe('[DELETE] Content', () => {
       wrapper: createWrapper(),
     });
 
-    act(() => {
-      result.current.mutate({ path });
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({ path });
+      } catch (error) {
+        // We expect an error, so do nothing
+      }
     });
 
-    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.status).toBe('error');
+    expect(result.current.error).toBeDefined();
+
+    // @ts-ignore
+    expect(result.current.error?.response?.status).toBe(404);
   });
 });

--- a/src/restapi/content/get.test.tsx
+++ b/src/restapi/content/get.test.tsx
@@ -29,6 +29,8 @@ describe('[GET] Content', () => {
     await waitFor(() => expect(result.current.isError).toBe(true));
 
     expect(result.current.error).toBeDefined();
+    // @ts-expect-error TODO: find a way to set the error type properly for error
+    expect(result.current.error.response?.status).toBe(404);
   });
 
   test('Hook - fullobjects', async () => {

--- a/src/restapi/content/get.test.tsx
+++ b/src/restapi/content/get.test.tsx
@@ -28,8 +28,6 @@ describe('[GET] Content', () => {
 
     await waitFor(() => expect(result.current.isError).toBe(true));
 
-    // @ts-ignore
-    expect(result.current.error.status).toBe(404);
     expect(result.current.error).toBeDefined();
   });
 

--- a/src/restapi/content/update.test.tsx
+++ b/src/restapi/content/update.test.tsx
@@ -73,5 +73,7 @@ describe('[PATCH] Content', () => {
 
     expect(result.current.status).toBe('error');
     expect(result.current.error).toBeDefined();
+    // @ts-expect-error TODO: find a way to set the error type properly for error
+    expect(result.current.error.response?.status).toBe(404);
   });
 });

--- a/src/restapi/content/update.test.tsx
+++ b/src/restapi/content/update.test.tsx
@@ -41,9 +41,9 @@ describe('[PATCH] Content', () => {
       wrapper: createWrapper(),
     });
 
-    act(() => {
-      result.current.mutate({ path: pagePath, data: dataPatch });
-    });
+    await act(() =>
+      result.current.mutateAsync({ path: pagePath, data: dataPatch }),
+    );
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
@@ -63,14 +63,15 @@ describe('[PATCH] Content', () => {
       wrapper: createWrapper(),
     });
 
-    act(() => {
-      result.current.mutate({ path, data });
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({ path, data });
+      } catch (error) {
+        // We expect an error, so do nothing
+      }
     });
 
-    await waitFor(() => expect(result.current.isError).toBe(true));
-
-    // @ts-ignore
-    expect(result.current.error.status).toBe(404);
+    expect(result.current.status).toBe('error');
     expect(result.current.error).toBeDefined();
   });
 });

--- a/src/restapi/contextnavigation/get.test.tsx
+++ b/src/restapi/contextnavigation/get.test.tsx
@@ -36,8 +36,6 @@ describe('[GET] ContextNavigation', () => {
 
     await waitFor(() => expect(result.current.isError).toBe(true));
 
-    // @ts-ignore
-    expect(result.current.error.status).toBe(404);
     expect(result.current.error).toBeDefined();
   });
 });

--- a/src/restapi/contextnavigation/get.test.tsx
+++ b/src/restapi/contextnavigation/get.test.tsx
@@ -37,5 +37,7 @@ describe('[GET] ContextNavigation', () => {
     await waitFor(() => expect(result.current.isError).toBe(true));
 
     expect(result.current.error).toBeDefined();
+    // @ts-expect-error TODO: find a way to set the error type properly for error
+    expect(result.current.error.response?.status).toBe(404);
   });
 });

--- a/src/restapi/navigation/get.test.tsx
+++ b/src/restapi/navigation/get.test.tsx
@@ -36,8 +36,6 @@ describe('[GET] Navigation', () => {
 
     await waitFor(() => expect(result.current.isError).toBe(true));
 
-    // @ts-ignore
-    expect(result.current.error.status).toBe(404);
     expect(result.current.error).toBeDefined();
   });
 });

--- a/src/restapi/navigation/get.test.tsx
+++ b/src/restapi/navigation/get.test.tsx
@@ -37,5 +37,7 @@ describe('[GET] Navigation', () => {
     await waitFor(() => expect(result.current.isError).toBe(true));
 
     expect(result.current.error).toBeDefined();
+    // @ts-expect-error TODO: find a way to set the error type properly for error
+    expect(result.current.error.response?.status).toBe(404);
   });
 });

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -2,29 +2,35 @@
 const HEADERS = ['range', 'if-range'];
 
 /**
- * Create a function that add X-Forwarded Headers to superagent requests
+ * Create a function that add X-Forwarded Headers to Axios requests
  * @function addHeadersFactory
  * @param {Object} req Original request object
- * @return {function} Superagent request function
+ * @return {function} Axios request interceptor
  */
-export const addHeadersFactory = (orig) => {
+export const addHeadersFactory = (orig): function => {
   return (request) => {
     const x_forwarded_host = orig.headers['x-forwarded-host'] || orig.hostname;
     const x_forwarded_for = orig.headers['x-forwarded-for'];
     const remote_host = orig.connection.remoteAddress;
+
     if (x_forwarded_for && remote_host) {
-      request.set('x-forwarded-for', x_forwarded_for + ', ' + remote_host);
+      request.headers['x-forwarded-for'] = x_forwarded_for + ', ' + remote_host;
     } else if (remote_host) {
-      request.set('x-forwarded-for', remote_host);
+      request.headers['x-forwarded-for'] = remote_host;
     } else if (x_forwarded_for) {
-      request.set('x-forwarded-for', x_forwarded_for);
+      request.headers['x-forwarded-for'] = x_forwarded_for;
     }
-    x_forwarded_host && request.set('x-forwarded-host', x_forwarded_host);
-    // forward additional headers
+
+    x_forwarded_host &&
+      (request.headers['x-forwarded-host'] = x_forwarded_host);
+
+    // Forward additional headers
     HEADERS.forEach((header) => {
       if (orig.headers[header]) {
-        request.set(header, orig.headers[header]);
+        request.headers[header] = orig.headers[header];
       }
     });
+
+    return request;
   };
 };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,5 +8,19 @@ export default defineConfig({
     // you might want to disable it, if you don't have tests that rely on CSS
     // since parsing CSS is slow
     css: true,
+    environmentOptions: {
+      jsdom: {
+        /*
+          We need to set the url parameter below to the url of the API server 
+          to avoid CORS issue. This is because JSDom environment sets the 
+          origin header (axios cannot control it on its own, just like in a 
+          browser) automatically to the url specified here. 
+          
+          If this url is not provided then vitest sets the default value as 
+          localhost:3000 which causes CORS error with the test server.
+        */
+        url: 'http://localhost:55001',
+      },
+    },
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1088,6 +1088,7 @@ __metadata:
     "@typescript-eslint/parser": 5.57.1
     "@vitejs/plugin-react": ^4.0.0
     "@vitest/coverage-c8": 0.28.5
+    axios: ^1.4.0
     eslint: 8.38.0
     eslint-config-prettier: 8.8.0
     eslint-plugin-prettier: 4.2.1
@@ -1097,7 +1098,6 @@ __metadata:
     react: ^18.2.0
     react-dom: ^18.2.0
     release-it: 15.10.1
-    superagent: 8.0.9
     typescript: 5.0.4
     universal-cookie: ^4.0.4
     vite: ^4.3.8
@@ -2053,13 +2053,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"asap@npm:^2.0.0":
-  version: 2.0.6
-  resolution: "asap@npm:2.0.6"
-  checksum: b296c92c4b969e973260e47523207cd5769abd27c245a68c26dc7a0fe8053c55bb04360237cb51cab1df52be939da77150ace99ad331fb7fb13b3423ed73ff3d
-  languageName: node
-  linkType: hard
-
 "assertion-error@npm:^1.1.0":
   version: 1.1.0
   resolution: "assertion-error@npm:1.1.0"
@@ -2106,6 +2099,17 @@ __metadata:
     follow-redirects: ^1.14.9
     form-data: ^4.0.0
   checksum: 38cb7540465fe8c4102850c4368053c21683af85c5fdf0ea619f9628abbcb59415d1e22ebc8a6390d2bbc9b58a9806c874f139767389c862ec9b772235f06854
+  languageName: node
+  linkType: hard
+
+"axios@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "axios@npm:1.4.0"
+  dependencies:
+    follow-redirects: ^1.15.0
+    form-data: ^4.0.0
+    proxy-from-env: ^1.1.0
+  checksum: 7fb6a4313bae7f45e89d62c70a800913c303df653f19eafec88e56cea2e3821066b8409bc68be1930ecca80e861c52aa787659df0ffec6ad4d451c7816b9386b
   languageName: node
   linkType: hard
 
@@ -2595,13 +2599,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"component-emitter@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "component-emitter@npm:1.3.0"
-  checksum: b3c46de38ffd35c57d1c02488355be9f218e582aec72d72d1b8bbec95a3ac1b38c96cd6e03ff015577e68f550fbb361a3bfdbd9bb248be9390b7b3745691be6b
-  languageName: node
-  linkType: hard
-
 "concat-map@npm:0.0.1":
   version: 0.0.1
   resolution: "concat-map@npm:0.0.1"
@@ -2666,13 +2663,6 @@ __metadata:
   version: 0.4.2
   resolution: "cookie@npm:0.4.2"
   checksum: a00833c998bedf8e787b4c342defe5fa419abd96b32f4464f718b91022586b8f1bafbddd499288e75c037642493c83083da426c6a9080d309e3bd90fd11baa9b
-  languageName: node
-  linkType: hard
-
-"cookiejar@npm:^2.1.4":
-  version: 2.1.4
-  resolution: "cookiejar@npm:2.1.4"
-  checksum: c4442111963077dc0e5672359956d6556a195d31cbb35b528356ce5f184922b99ac48245ac05ed86cf993f7df157c56da10ab3efdadfed79778a0d9b1b092d5b
   languageName: node
   linkType: hard
 
@@ -2947,16 +2937,6 @@ __metadata:
   version: 2.3.1
   resolution: "deprecation@npm:2.3.1"
   checksum: f56a05e182c2c195071385455956b0c4106fe14e36245b00c689ceef8e8ab639235176a96977ba7c74afb173317fac2e0ec6ec7a1c6d1e6eaa401c586c714132
-  languageName: node
-  linkType: hard
-
-"dezalgo@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "dezalgo@npm:1.0.4"
-  dependencies:
-    asap: ^2.0.0
-    wrappy: 1
-  checksum: 895389c6aead740d2ab5da4d3466d20fa30f738010a4d3f4dcccc9fc645ca31c9d10b7e1804ae489b1eb02c7986f9f1f34ba132d409b043082a86d9a4e745624
   languageName: node
   linkType: hard
 
@@ -3724,13 +3704,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-safe-stringify@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "fast-safe-stringify@npm:2.1.1"
-  checksum: a851cbddc451745662f8f00ddb622d6766f9bd97642dabfd9a405fb0d646d69fc0b9a1243cbf67f5f18a39f40f6fa821737651ff1bceeba06c9992ca2dc5bd3d
-  languageName: node
-  linkType: hard
-
 "fastq@npm:^1.6.0":
   version: 1.15.0
   resolution: "fastq@npm:1.15.0"
@@ -3812,7 +3785,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.14.9":
+"follow-redirects@npm:^1.14.9, follow-redirects@npm:^1.15.0":
   version: 1.15.2
   resolution: "follow-redirects@npm:1.15.2"
   peerDependenciesMeta:
@@ -3865,18 +3838,6 @@ __metadata:
   dependencies:
     fetch-blob: ^3.1.2
   checksum: 82a34df292afadd82b43d4a740ce387bc08541e0a534358425193017bf9fb3567875dc5f69564984b1da979979b70703aa73dee715a17b6c229752ae736dd9db
-  languageName: node
-  linkType: hard
-
-"formidable@npm:^2.1.2":
-  version: 2.1.2
-  resolution: "formidable@npm:2.1.2"
-  dependencies:
-    dezalgo: ^1.0.4
-    hexoid: ^1.0.0
-    once: ^1.4.0
-    qs: ^6.11.0
-  checksum: 81c8e5d89f5eb873e992893468f0de22c01678ca3d315db62be0560f9de1c77d4faefc9b1f4575098eb2263b3c81ba1024833a9fc3206297ddbac88a4f69b7a8
   languageName: node
   linkType: hard
 
@@ -4329,13 +4290,6 @@ __metadata:
   dependencies:
     function-bind: ^1.1.1
   checksum: b9ad53d53be4af90ce5d1c38331e712522417d017d5ef1ebd0507e07c2fbad8686fffb8e12ddecd4c39ca9b9b47431afbb975b8abf7f3c3b82c98e9aad052792
-  languageName: node
-  linkType: hard
-
-"hexoid@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "hexoid@npm:1.0.0"
-  checksum: 27a148ca76a2358287f40445870116baaff4a0ed0acc99900bf167f0f708ffd82e044ff55e9949c71963852b580fc024146d3ac6d5d76b508b78d927fa48ae2d
   languageName: node
   linkType: hard
 
@@ -5566,13 +5520,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"methods@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "methods@npm:1.1.2"
-  checksum: 0917ff4041fa8e2f2fda5425a955fe16ca411591fbd123c0d722fcf02b73971ed6f764d85f0a6f547ce49ee0221ce2c19a5fa692157931cecb422984f1dcd13a
-  languageName: node
-  linkType: hard
-
 "micromatch@npm:^4.0.4":
   version: 4.0.5
   resolution: "micromatch@npm:4.0.5"
@@ -5596,15 +5543,6 @@ __metadata:
   dependencies:
     mime-db: 1.52.0
   checksum: 89a5b7f1def9f3af5dad6496c5ed50191ae4331cc5389d7c521c8ad28d5fdad2d06fd81baf38fed813dc4e46bb55c8145bb0ff406330818c9cf712fb2e9b3836
-  languageName: node
-  linkType: hard
-
-"mime@npm:2.6.0":
-  version: 2.6.0
-  resolution: "mime@npm:2.6.0"
-  bin:
-    mime: cli.js
-  checksum: 1497ba7b9f6960694268a557eae24b743fd2923da46ec392b042469f4b901721ba0adcf8b0d3c2677839d0e243b209d76e5edcbd09cfdeffa2dfb6bb4df4b862
   languageName: node
   linkType: hard
 
@@ -6568,7 +6506,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proxy-from-env@npm:^1.0.0":
+"proxy-from-env@npm:^1.0.0, proxy-from-env@npm:^1.1.0":
   version: 1.1.0
   resolution: "proxy-from-env@npm:1.1.0"
   checksum: ed7fcc2ba0a33404958e34d95d18638249a68c430e30fcb6c478497d72739ba64ce9810a24f53a7d921d0c065e5b78e3822759800698167256b04659366ca4d4
@@ -6595,15 +6533,6 @@ __metadata:
   dependencies:
     escape-goat: ^4.0.0
   checksum: 0e4f4ab6bbdce600fa6d23b1833f1af57b2641246ff4cbe10f9d66e4e5479b0de2864a88d5bd629eef59524eda3c6680726acd7f3f873d9ed46b7f095d0bb5f6
-  languageName: node
-  linkType: hard
-
-"qs@npm:^6.11.0":
-  version: 6.11.0
-  resolution: "qs@npm:6.11.0"
-  dependencies:
-    side-channel: ^1.0.4
-  checksum: 6e1f29dd5385f7488ec74ac7b6c92f4d09a90408882d0c208414a34dd33badc1a621019d4c799a3df15ab9b1d0292f97c1dd71dc7c045e69f81a8064e5af7297
   languageName: node
   linkType: hard
 
@@ -7116,7 +7045,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:7.3.8, semver@npm:^7.3.2, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:~7.3.0":
+"semver@npm:7.3.8, semver@npm:^7.3.2, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:~7.3.0":
   version: 7.3.8
   resolution: "semver@npm:7.3.8"
   dependencies:
@@ -7499,24 +7428,6 @@ __metadata:
   dependencies:
     acorn: ^8.8.2
   checksum: ab40496820f02220390d95cdd620a997168efb69d5bd7d180bc4ef83ca562a95447843d8c7c88b8284879a29cf4eedc89d8001d1e098c1a1e23d12a9c755dff4
-  languageName: node
-  linkType: hard
-
-"superagent@npm:8.0.9":
-  version: 8.0.9
-  resolution: "superagent@npm:8.0.9"
-  dependencies:
-    component-emitter: ^1.3.0
-    cookiejar: ^2.1.4
-    debug: ^4.3.4
-    fast-safe-stringify: ^2.1.1
-    form-data: ^4.0.0
-    formidable: ^2.1.2
-    methods: ^1.1.2
-    mime: 2.6.0
-    qs: ^6.11.0
-    semver: ^7.3.8
-  checksum: 5d00cdc7ceb5570663da80604965750e6b1b8d7d7442b7791e285c62bcd8d578a8ead0242a2426432b59a255fb42eb3a196d636157538a1392e7b6c5f1624810
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR introduces the following changes:

1. Replacement of superagent library with axios.
2. Refactoring the API.ts file and test files to work with axios.
3. Changes in vitest.config.ts file as vitest sets the `origin` header as `localhost:3000` by default which results in CORS error.