### PR TITLE
01 - Add actions for more services - groups, history and users 

### DIFF
--- a/news/25.feature
+++ b/news/25.feature
@@ -1,0 +1,1 @@
+Add more services to restapi, namely groups, history and users along with their tests and associated types @hemant-hc

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   ],
   "scripts": {
     "build": "vite build",
-    "test": "vitest --no-threads",
+    "test": "node testRunner.js",
     "check-ts": "tsc --project tsconfig.json",
     "coverage": "vitest run --coverage --no-threads",
     "lint": "eslint 'src/**/*.{js,ts,tsx}' --quiet",

--- a/src/client.ts
+++ b/src/client.ts
@@ -167,6 +167,7 @@ export default class PloneClient {
   /*
     Database queries
   */
+
   getDatabaseQuery = queryWithConfig(_getDatabaseQuery, this.getConfig);
   /*
     Group queries

--- a/src/client.ts
+++ b/src/client.ts
@@ -32,6 +32,7 @@ import { updateGroupMutation as _updateGroupMutation } from './restapi/groups/up
 import { deleteGroupMutation as _deleteGroupMutation } from './restapi/groups/delete';
 import { getHistoryQuery as _getHistoryQuery } from './restapi/history/get';
 import { getHistoryVersionedQuery as _getHistoryVersionedQuery } from './restapi/history/get_versioned';
+import { revertHistoryMutation as _revertHistoryMutation } from './restapi/history/revert';
 import { getUsersQuery as _getUsersQuery } from './restapi/users/get_list';
 import { getUserQuery as _getUserQuery } from './restapi/users/get';
 import { createUserMutation as _createUserMutation } from './restapi/users/add';
@@ -193,6 +194,10 @@ export default class PloneClient {
   getHistoryQuery = queryWithConfig(_getHistoryQuery, this.getConfig);
   getHistoryVersionedQuery = queryWithConfig(
     _getHistoryVersionedQuery,
+    this.getConfig,
+  );
+  revertHistoryMutation = mutationWithConfig(
+    _revertHistoryMutation,
     this.getConfig,
   );
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -25,6 +25,21 @@ import { installAddonProfileMutation as _installAddonProfileMutation } from './r
 import { uninstallAddonMutation as _uninstallAddonMutation } from './restapi/addons/unistall';
 import { upgradeAddonMutation as _upgradeAddonMutation } from './restapi/addons/upgrade';
 import { getDatabaseQuery as _getDatabaseQuery } from './restapi/database/get';
+import { getGroupQuery as _getGroupQuery } from './restapi/groups/get';
+import { createGroupMutation as _createGroupMutation } from './restapi/groups/add';
+import { getGroupsQuery as _getGroupsQuery } from './restapi/groups/get_list';
+import { updateGroupMutation as _updateGroupMutation } from './restapi/groups/update';
+import { deleteGroupMutation as _deleteGroupMutation } from './restapi/groups/delete';
+import { getHistoryQuery as _getHistoryQuery } from './restapi/history/get';
+import { getHistoryVersionedQuery as _getHistoryVersionedQuery } from './restapi/history/get_versioned';
+import { getUsersQuery as _getUsersQuery } from './restapi/users/get_list';
+import { getUserQuery as _getUserQuery } from './restapi/users/get';
+import { createUserMutation as _createUserMutation } from './restapi/users/add';
+import { deleteUserMutation as _deleteUserMutation } from './restapi/users/delete';
+import { resetPasswordMutation as _resetPasswordMutation } from './restapi/users/reset_password';
+import { resetPasswordWithTokenMutation as _resetPasswordWithTokenMutation } from './restapi/users/reset_password_with_token';
+import { updatePasswordMutation as _updatePasswordMutation } from './restapi/users/update_password';
+import { updateUserMutation as _updateUserMutation } from './restapi/users/update';
 
 import { mutationWithConfig, queryWithConfig } from './utils/misc';
 import { PloneClientConfig } from './interfaces/config';
@@ -153,4 +168,51 @@ export default class PloneClient {
     Database queries
   */
   getDatabaseQuery = queryWithConfig(_getDatabaseQuery, this.getConfig);
+  /*
+    Group queries
+  */
+  getGroupsQuery = queryWithConfig(_getGroupsQuery, this.getConfig);
+  getGroupQuery = queryWithConfig(_getGroupQuery, this.getConfig);
+  createGroupMutation = mutationWithConfig(
+    _createGroupMutation,
+    this.getConfig,
+  );
+  updateGroupMutation = mutationWithConfig(
+    _updateGroupMutation,
+    this.getConfig,
+  );
+  deleteGroupMutation = mutationWithConfig(
+    _deleteGroupMutation,
+    this.getConfig,
+  );
+
+  /*
+    History queries
+  */
+  getHistoryQuery = queryWithConfig(_getHistoryQuery, this.getConfig);
+  getHistoryVersionedQuery = queryWithConfig(
+    _getHistoryVersionedQuery,
+    this.getConfig,
+  );
+
+  /*
+    User queries
+  */
+  getUsersQuery = queryWithConfig(_getUsersQuery, this.getConfig);
+  getUserQuery = queryWithConfig(_getUserQuery, this.getConfig);
+  createUserMutation = mutationWithConfig(_createUserMutation, this.getConfig);
+  deleteUserMutation = mutationWithConfig(_deleteUserMutation, this.getConfig);
+  resetPasswordMutation = mutationWithConfig(
+    _resetPasswordMutation,
+    this.getConfig,
+  );
+  resetPasswordWithTokenMutation = mutationWithConfig(
+    _resetPasswordWithTokenMutation,
+    this.getConfig,
+  );
+  updatePasswordMutation = mutationWithConfig(
+    _updatePasswordMutation,
+    this.getConfig,
+  );
+  updateUserMutation = mutationWithConfig(_updateUserMutation, this.getConfig);
 }

--- a/src/interfaces/groups.ts
+++ b/src/interfaces/groups.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+
+export interface GetGroupResponse {
+  '@id': string;
+  description: string;
+  email: string;
+  groupname: string;
+  id: string;
+  members: {
+    '@id': string;
+    items: any[];
+    items_total: number;
+  };
+  roles: string[];
+  title: string;
+}
+
+export interface GetGroupsResponse extends Array<GetGroupResponse> {}
+
+export const createGroupDataSchema = z.object({
+  description: z.string().optional(),
+  email: z.string().optional(),
+  groupname: z.string(),
+  groups: z.array(z.string()).optional(),
+  roles: z.array(z.string()).optional(),
+  title: z.string().optional(),
+  users: z.array(z.string()).optional(),
+});
+
+export const updateGroupDataSchema = z.object({
+  description: z.string().optional(),
+  email: z.string().optional(),
+  title: z.string().optional(),
+});
+
+export interface CreateGroupResponse extends GetGroupResponse {}

--- a/src/interfaces/history.ts
+++ b/src/interfaces/history.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 interface Actor {
   '@id': string;
   fullname: string;
@@ -29,3 +31,11 @@ interface ActionCreate {
 }
 
 export type GetHistoryResponse = (ActionCreate | ActionEdited)[];
+
+export const revertHistoryDataSchema = z.object({
+  version: z.number(),
+});
+
+export interface revertHistoryResponse {
+  message: string;
+}

--- a/src/interfaces/history.ts
+++ b/src/interfaces/history.ts
@@ -1,0 +1,31 @@
+interface Actor {
+  '@id': string;
+  fullname: string;
+  id: string;
+  username: string | null;
+}
+
+interface ActionEdited {
+  '@id': string;
+  action: string;
+  actor: Actor;
+  comments: string;
+  may_revert: boolean;
+  time: string;
+  transition_title: string;
+  type: string;
+  version: number;
+}
+
+interface ActionCreate {
+  action: string;
+  actor: Actor;
+  comments: string;
+  review_state: string;
+  state_title: string;
+  time: string;
+  transition_title: string;
+  type: string;
+}
+
+export type GetHistoryResponse = (ActionCreate | ActionEdited)[];

--- a/src/interfaces/users.ts
+++ b/src/interfaces/users.ts
@@ -1,0 +1,64 @@
+import { z } from 'zod';
+
+export interface User {
+  '@id': string;
+  description: string;
+  email: string;
+  fullname: string;
+  groups: {
+    '@id': string;
+    items: {
+      id: string;
+      title: string;
+    }[];
+    items_total: number;
+  };
+  home_page: string;
+  id: string;
+  location: string;
+  portrait: null;
+  roles: string[];
+  username: string;
+}
+
+export type GetUsersResponse = Array<User>;
+
+export const createUserDataSchema = z.object({
+  description: z.string().optional(),
+  email: z.string().email(),
+  fullname: z.string().optional(),
+  home_page: z.string().url().optional(),
+  location: z.string().optional(),
+  sendPasswordReset: z.boolean().optional(),
+  username: z.string(),
+  roles: z.array(z.string()).optional(),
+  password: z.string().optional(),
+});
+
+const portraitSchema = z.object({
+  'content-type': z.string(),
+  data: z.string(),
+  encoding: z.string(),
+  filename: z.string(),
+  scale: z.boolean().optional(),
+});
+
+export const updateUserDataSchema = z.object({
+  description: z.string().optional(),
+  email: z.string().email().optional(),
+  fullname: z.string().optional(),
+  home_page: z.string().url().optional(),
+  location: z.string().optional(),
+  username: z.string().optional(),
+  portrait: portraitSchema.optional(),
+});
+
+export const resetPasswordWithTokenDataSchema = z.object({
+  reset_token: z.string(),
+  new_password: z.string(),
+});
+
+export const updatePasswordDataSchema = z.object({
+  new_password: z.string(),
+  old_password: z.string(),
+});

--- a/src/restapi/groups/add.test.tsx
+++ b/src/restapi/groups/add.test.tsx
@@ -1,0 +1,43 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { createWrapper } from '../../testUtils';
+import { useMutation } from '@tanstack/react-query';
+import { setup, teardown } from '../../resetFixture';
+import { beforeEach } from 'vitest';
+import { expect, test } from 'vitest';
+import PloneClient from '../../client';
+import { v4 as uuid } from 'uuid';
+
+const cli = PloneClient.initialize({
+  apiPath: 'http://localhost:55001/plone',
+});
+
+const { login, createGroupMutation } = cli;
+await login({ username: 'admin', password: 'secret' });
+
+beforeEach(async () => {
+  await setup();
+});
+
+afterEach(async () => {
+  await teardown();
+});
+
+describe('[POST] Group', () => {
+  test('Hook - Successful', async () => {
+    const randomId = uuid();
+    const { result } = renderHook(() => useMutation(createGroupMutation()), {
+      wrapper: createWrapper(),
+    });
+
+    const groupData = {
+      groupname: `addgroup${randomId}`,
+    };
+
+    act(() => {
+      result.current.mutate({ data: groupData });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.id).toBe(groupData.groupname);
+  });
+});

--- a/src/restapi/groups/add.ts
+++ b/src/restapi/groups/add.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod';
+import { ApiRequestParams, apiRequest } from '../../API';
+import {
+  PloneClientConfig,
+  PloneClientConfigSchema,
+} from '../../interfaces/config';
+import {
+  CreateGroupResponse,
+  createGroupDataSchema,
+} from '../../interfaces/groups';
+
+export const createGroupArgsSchema = z.object({
+  data: createGroupDataSchema,
+  config: PloneClientConfigSchema,
+});
+
+export type CreateGroupArgs = z.infer<typeof createGroupArgsSchema>;
+
+export const createGroup = async ({
+  data,
+  config,
+}: CreateGroupArgs): Promise<CreateGroupResponse> => {
+  const validatedArgs = createGroupArgsSchema.parse({
+    data,
+    config,
+  });
+
+  const options: ApiRequestParams = {
+    data: validatedArgs.data,
+    config: validatedArgs.config,
+  };
+
+  return apiRequest('post', '/@groups', options);
+};
+
+export const createGroupMutation = ({
+  config,
+}: {
+  config: PloneClientConfig;
+}) => ({
+  mutationKey: ['post', 'groups'],
+  mutationFn: ({ data }: Omit<CreateGroupArgs, 'config'>) =>
+    createGroup({ data, config }),
+});

--- a/src/restapi/groups/delete.test.tsx
+++ b/src/restapi/groups/delete.test.tsx
@@ -1,0 +1,61 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { createWrapper } from '../../testUtils';
+import { useMutation } from '@tanstack/react-query';
+import { setup, teardown } from '../../resetFixture';
+import { beforeEach } from 'vitest';
+import { expect, test } from 'vitest';
+import PloneClient from '../../client';
+import { createGroup } from './add';
+import { v4 as uuid } from 'uuid';
+
+const cli = PloneClient.initialize({
+  apiPath: 'http://localhost:55001/plone',
+});
+
+const { login, deleteGroupMutation } = cli;
+await login({ username: 'admin', password: 'secret' });
+
+beforeEach(async () => {
+  await setup();
+});
+
+afterEach(async () => {
+  await teardown();
+});
+
+describe('[DELETE] Group', () => {
+  test('Hook - Successful', async () => {
+    const randomId = uuid();
+    const groupData = {
+      groupname: `deletegroup${randomId}`,
+    };
+
+    await createGroup({ data: groupData, config: cli.config });
+
+    const { result } = renderHook(() => useMutation(deleteGroupMutation()), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.mutate({ groupId: groupData.groupname });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+
+  test('Hook - Failure', async () => {
+    const groupId = 'blah';
+
+    const { result } = renderHook(() => useMutation(deleteGroupMutation()), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.mutate({ groupId });
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toBeDefined();
+  });
+});

--- a/src/restapi/groups/delete.ts
+++ b/src/restapi/groups/delete.ts
@@ -1,0 +1,41 @@
+import { apiRequest, ApiRequestParams } from '../../API';
+import { z } from 'zod';
+import {
+  PloneClientConfig,
+  PloneClientConfigSchema,
+} from '../../interfaces/config';
+
+export const deleteGroupArgsSchema = z.object({
+  groupId: z.string(),
+  config: PloneClientConfigSchema,
+});
+
+type DeleteGroupArgs = z.infer<typeof deleteGroupArgsSchema>;
+
+export const deleteGroup = async ({
+  groupId,
+  config,
+}: DeleteGroupArgs): Promise<undefined> => {
+  const validatedArgs = deleteGroupArgsSchema.parse({
+    groupId,
+    config,
+  });
+
+  const options: ApiRequestParams = {
+    config: validatedArgs.config,
+  };
+
+  const groupName = `/@groups/${validatedArgs.groupId}`;
+
+  return apiRequest('delete', groupName, options);
+};
+
+export const deleteGroupMutation = ({
+  config,
+}: {
+  config: PloneClientConfig;
+}) => ({
+  mutationKey: ['delete', 'groups'],
+  mutationFn: ({ groupId }: Omit<DeleteGroupArgs, 'config'>) =>
+    deleteGroup({ groupId, config }),
+});

--- a/src/restapi/groups/get.test.tsx
+++ b/src/restapi/groups/get.test.tsx
@@ -1,0 +1,58 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { createWrapper } from '../../testUtils';
+import { useQuery } from '@tanstack/react-query';
+import ploneClient from '../../client';
+import { createGroup } from './add';
+import { v4 as uuid } from 'uuid';
+
+const cli = ploneClient.initialize({
+  apiPath: 'http://localhost:55001/plone',
+});
+
+const { login, getGroupQuery } = cli;
+await login({ username: 'admin', password: 'secret' });
+
+describe('[GET] Group', () => {
+  test('Hook - Successful', async () => {
+    const groupId = '/Administrators';
+
+    const { result } = renderHook(() => useQuery(getGroupQuery({ groupId })), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.id).toBe('Administrators');
+  });
+
+  test('Hook - Successful - with create', async () => {
+    const randomId = uuid();
+    const groupData = {
+      groupname: `getgroup${randomId}`,
+    };
+
+    await createGroup({ data: groupData, config: cli.config });
+
+    const { result } = renderHook(
+      () => useQuery(getGroupQuery({ groupId: groupData.groupname })),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.id).toBe(groupData.groupname);
+  });
+
+  test('Hook - Failure', async () => {
+    const groupId = 'blah';
+    const { result } = renderHook(() => useQuery(getGroupQuery({ groupId })), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toBeDefined();
+  });
+});

--- a/src/restapi/groups/get.ts
+++ b/src/restapi/groups/get.ts
@@ -1,0 +1,34 @@
+import { apiRequest, ApiRequestParams } from '../../API';
+import { PloneClientConfig } from '../../interfaces/config';
+import { z } from 'zod';
+import { GetGroupResponse } from '../../interfaces/groups';
+
+const getGroupSchema = z.object({
+  groupId: z.string(),
+});
+
+export type GroupArgs = z.infer<typeof getGroupSchema> & {
+  config: PloneClientConfig;
+};
+
+export const getGroup = async ({
+  groupId,
+  config,
+}: GroupArgs): Promise<GetGroupResponse> => {
+  const validatedArgs = getGroupSchema.parse({
+    groupId,
+  });
+
+  const options: ApiRequestParams = {
+    config,
+    params: {},
+  };
+  const groupName = `@groups/${validatedArgs.groupId}`;
+
+  return apiRequest('get', groupName, options);
+};
+
+export const getGroupQuery = ({ groupId, config }: GroupArgs) => ({
+  queryKey: [groupId, 'get', 'groups'],
+  queryFn: () => getGroup({ groupId, config }),
+});

--- a/src/restapi/groups/get_list.test.tsx
+++ b/src/restapi/groups/get_list.test.tsx
@@ -1,0 +1,23 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { createWrapper } from '../../testUtils';
+import { useQuery } from '@tanstack/react-query';
+import ploneClient from '../../client';
+
+const cli = ploneClient.initialize({
+  apiPath: 'http://localhost:55001/plone',
+});
+
+const { login, getGroupsQuery } = cli;
+await login({ username: 'admin', password: 'secret' });
+
+describe('[GET] GroupsList', () => {
+  test('Hook - Successful', async () => {
+    const { result } = renderHook(() => useQuery(getGroupsQuery({})), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.[0]).toHaveProperty('id');
+  });
+});

--- a/src/restapi/groups/get_list.ts
+++ b/src/restapi/groups/get_list.ts
@@ -1,0 +1,23 @@
+import { apiRequest, ApiRequestParams } from '../../API';
+import { PloneClientConfig } from '../../interfaces/config';
+import { GetGroupsResponse } from '../../interfaces/groups';
+
+export type GroupsArgs = {
+  config: PloneClientConfig;
+};
+
+export const getGroups = async ({
+  config,
+}: GroupsArgs): Promise<GetGroupsResponse> => {
+  const options: ApiRequestParams = {
+    config,
+    params: {},
+  };
+
+  return apiRequest('get', '/@groups', options);
+};
+
+export const getGroupsQuery = ({ config }: GroupsArgs) => ({
+  queryKey: ['get', 'groups'],
+  queryFn: () => getGroups({ config }),
+});

--- a/src/restapi/groups/update.test.tsx
+++ b/src/restapi/groups/update.test.tsx
@@ -1,0 +1,80 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { createWrapper } from '../../testUtils';
+import { useMutation } from '@tanstack/react-query';
+import { setup, teardown } from '../../resetFixture';
+import { beforeEach } from 'vitest';
+import { expect, test } from 'vitest';
+import PloneClient from '../../client';
+import { createGroup } from './add';
+import { getGroup } from './get';
+import { v4 as uuid } from 'uuid';
+
+const cli = PloneClient.initialize({
+  apiPath: 'http://localhost:55001/plone',
+});
+
+const { login, updateGroupMutation } = cli;
+await login({ username: 'admin', password: 'secret' });
+
+beforeEach(async () => {
+  await setup();
+});
+
+afterEach(async () => {
+  await teardown();
+});
+
+describe('[PATCH] Group', () => {
+  test('Hook - Successful', async () => {
+    const randomId = uuid();
+    const groupData = {
+      groupname: `updategroup${randomId}`,
+      description: 'new description',
+    };
+
+    await createGroup({ data: groupData, config: cli.config });
+
+    const { result } = renderHook(() => useMutation(updateGroupMutation()), {
+      wrapper: createWrapper(),
+    });
+
+    const updateGroupData = {
+      description: 'changed description',
+    };
+
+    act(() => {
+      result.current.mutate({
+        groupId: groupData.groupname,
+        data: updateGroupData,
+      });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const group = await getGroup({
+      groupId: groupData.groupname,
+      config: cli.config,
+    });
+
+    expect(group?.description).toBe('changed description');
+  });
+
+  test('Hook - Failure', async () => {
+    const groupId = 'blah';
+    const updateGroupData = {
+      description: 'asd',
+    };
+
+    const { result } = renderHook(() => useMutation(updateGroupMutation()), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.mutate({ groupId, data: updateGroupData });
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toBeDefined();
+  });
+});

--- a/src/restapi/groups/update.ts
+++ b/src/restapi/groups/update.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+import { ApiRequestParams, apiRequest } from '../../API';
+import {
+  PloneClientConfig,
+  PloneClientConfigSchema,
+} from '../../interfaces/config';
+import { updateGroupDataSchema } from '../../interfaces/groups';
+
+export const updateGroupArgsSchema = z.object({
+  groupId: z.string(),
+  data: updateGroupDataSchema,
+  config: PloneClientConfigSchema,
+});
+
+export type UpdateGroupArgs = z.infer<typeof updateGroupArgsSchema>;
+
+export const updateGroup = async ({
+  groupId,
+  data,
+  config,
+}: UpdateGroupArgs): Promise<undefined> => {
+  const validatedArgs = updateGroupArgsSchema.parse({
+    groupId,
+    data,
+    config,
+  });
+
+  const options: ApiRequestParams = {
+    data: validatedArgs.data,
+    config: validatedArgs.config,
+  };
+
+  const groupName = `/@groups/${validatedArgs.groupId}`;
+
+  return apiRequest('patch', groupName, options);
+};
+
+export const updateGroupMutation = ({
+  config,
+}: {
+  config: PloneClientConfig;
+}) => ({
+  mutationKey: ['patch', 'groups'],
+  mutationFn: ({ groupId, data }: Omit<UpdateGroupArgs, 'config'>) =>
+    updateGroup({ groupId, data, config }),
+});

--- a/src/restapi/history/get.test.tsx
+++ b/src/restapi/history/get.test.tsx
@@ -1,0 +1,45 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { createWrapper } from '../../testUtils';
+import { useQuery } from '@tanstack/react-query';
+import ploneClient from '../../client';
+import { createContent } from '../content/add';
+
+const cli = ploneClient.initialize({
+  apiPath: 'http://localhost:55001/plone',
+});
+
+const { login, getHistoryQuery } = cli;
+await login({ username: 'admin', password: 'secret' });
+
+describe('[GET] History', () => {
+  test('Hook - Successful', async () => {
+    const path = '/';
+    const contentData = {
+      '@type': 'Document',
+      title: 'front-page',
+    };
+    await createContent({ path, data: contentData, config: cli.config });
+
+    const { result } = renderHook(
+      () => useQuery(getHistoryQuery({ path: 'front-page' })),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.[0].action).toBe('Create');
+  });
+
+  test('Hook - Failure', async () => {
+    const path = '/blah';
+    const { result } = renderHook(() => useQuery(getHistoryQuery({ path })), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toBeDefined();
+  });
+});

--- a/src/restapi/history/get.ts
+++ b/src/restapi/history/get.ts
@@ -1,0 +1,34 @@
+import { apiRequest, ApiRequestParams } from '../../API';
+import { PloneClientConfig } from '../../interfaces/config';
+import { z } from 'zod';
+import { GetHistoryResponse } from '../../interfaces/history';
+
+const getHistorySchema = z.object({
+  path: z.string(),
+});
+
+export type HistoryArgs = z.infer<typeof getHistorySchema> & {
+  config: PloneClientConfig;
+};
+
+export const getHistory = async ({
+  path,
+  config,
+}: HistoryArgs): Promise<GetHistoryResponse> => {
+  const validatedArgs = getHistorySchema.parse({
+    path,
+  });
+
+  const options: ApiRequestParams = {
+    config,
+    params: {},
+  };
+  const historyPath = `/${validatedArgs.path}/@history`;
+
+  return apiRequest('get', historyPath, options);
+};
+
+export const getHistoryQuery = ({ path, config }: HistoryArgs) => ({
+  queryKey: [path, 'get', 'history'],
+  queryFn: () => getHistory({ path, config }),
+});

--- a/src/restapi/history/get_versioned.test.tsx
+++ b/src/restapi/history/get_versioned.test.tsx
@@ -1,0 +1,71 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { createWrapper } from '../../testUtils';
+import { useQuery } from '@tanstack/react-query';
+import ploneClient from '../../client';
+import { createContent } from '../content/add';
+import { updateContent } from '../content/update';
+import { setup, teardown } from '../../resetFixture';
+
+const cli = ploneClient.initialize({
+  apiPath: 'http://localhost:55001/plone',
+});
+
+const { login, getHistoryVersionedQuery } = cli;
+await login({ username: 'admin', password: 'secret' });
+
+beforeEach(async () => {
+  await setup();
+});
+
+afterEach(async () => {
+  await teardown();
+});
+
+describe('[GET] HistoryVersioned', () => {
+  test('Hook - Successful', async () => {
+    const contentData = {
+      '@type': 'Document',
+      title: `historyversion`,
+      versioning_enabled: true,
+    };
+
+    await createContent({ path: '/', data: contentData, config: cli.config });
+
+    const { result } = renderHook(
+      () =>
+        useQuery(
+          getHistoryVersionedQuery({
+            path: contentData.title,
+            version: 0,
+          }),
+        ),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(false));
+
+    // TODO: Find why versioning_enabled is not working
+  });
+
+  test('Hook - Failure', async () => {
+    const path = '/blah';
+    const { result } = renderHook(
+      () =>
+        useQuery(
+          getHistoryVersionedQuery({
+            path,
+            version: 0,
+          }),
+        ),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toBeDefined();
+  });
+});

--- a/src/restapi/history/get_versioned.ts
+++ b/src/restapi/history/get_versioned.ts
@@ -1,0 +1,40 @@
+import { apiRequest, ApiRequestParams } from '../../API';
+import { PloneClientConfig } from '../../interfaces/config';
+import { z } from 'zod';
+
+const getHistoryVersionedSchema = z.object({
+  path: z.string(),
+  version: z.number(),
+});
+
+export type HistoryVersionedArgs = z.infer<typeof getHistoryVersionedSchema> & {
+  config: PloneClientConfig;
+};
+
+export const getHistoryVersioned = async ({
+  path,
+  version,
+  config,
+}: HistoryVersionedArgs): Promise<unknown> => {
+  const validatedArgs = getHistoryVersionedSchema.parse({
+    path,
+    version,
+  });
+
+  const options: ApiRequestParams = {
+    config,
+    params: {},
+  };
+  const historyPath = `${validatedArgs.path}/@history/${validatedArgs.version}`;
+
+  return apiRequest('get', historyPath, options);
+};
+
+export const getHistoryVersionedQuery = ({
+  path,
+  version,
+  config,
+}: HistoryVersionedArgs) => ({
+  queryKey: [path, 'get', 'history'],
+  queryFn: () => getHistoryVersioned({ path, version, config }),
+});

--- a/src/restapi/history/revert.ts
+++ b/src/restapi/history/revert.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+import { apiRequest, ApiRequestParams } from '../../API';
+import {
+  PloneClientConfig,
+  PloneClientConfigSchema,
+} from '../../interfaces/config';
+import { revertHistoryDataSchema } from '../../interfaces/history';
+
+export const revertHistoryArgsSchema = z.object({
+  path: z.string(),
+  data: revertHistoryDataSchema,
+  config: PloneClientConfigSchema,
+});
+
+export type ReverHistoryArgs = z.infer<typeof revertHistoryArgsSchema>;
+
+export const revertHistory = async ({
+  path,
+  data,
+  config,
+}: ReverHistoryArgs): Promise<undefined> => {
+  const validatedArgs = revertHistoryArgsSchema.parse({
+    path,
+    data,
+    config,
+  });
+
+  const options: ApiRequestParams = {
+    data: validatedArgs.data,
+    config: validatedArgs.config,
+  };
+
+  const historyPath = `${validatedArgs.path}/@history`;
+
+  return apiRequest('patch', historyPath, options);
+};
+
+export const revertHistoryMutation = ({
+  config,
+}: {
+  config: PloneClientConfig;
+}) => ({
+  mutationKey: ['patch', 'history'],
+  mutationFn: ({ path, data }: Omit<ReverHistoryArgs, 'config'>) =>
+    revertHistory({ path, data, config }),
+});

--- a/src/restapi/users/add.test.tsx
+++ b/src/restapi/users/add.test.tsx
@@ -1,0 +1,67 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { createWrapper } from '../../testUtils';
+import { useMutation } from '@tanstack/react-query';
+import { setup, teardown } from '../../resetFixture';
+import { beforeEach } from 'vitest';
+import { expect, test } from 'vitest';
+import PloneClient from '../../client';
+import { v4 as uuid } from 'uuid';
+
+const cli = PloneClient.initialize({
+  apiPath: 'http://localhost:55001/plone',
+});
+
+const { login, createUserMutation } = cli;
+await login({ username: 'admin', password: 'secret' });
+
+beforeEach(async () => {
+  await setup();
+});
+
+afterEach(async () => {
+  await teardown();
+});
+
+describe('[POST] UserAdd', () => {
+  test('Hook - Successful with resetPassword', async () => {
+    const randomId = uuid();
+    const userData = {
+      username: `addTestUser${randomId}`,
+      email: `addTestUser${randomId}@example.com`,
+      password: 'password',
+    };
+
+    const { result } = renderHook(() => useMutation(createUserMutation()), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.mutate({ data: userData });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.id).toBe(userData.username);
+  });
+
+  test('Hook - Successful with password', async () => {
+    const randomId = uuid();
+    const userData = {
+      username: `addTestUser${randomId}`,
+      email: `addTestUser${randomId}@example.com`,
+      password: 'password',
+    };
+
+    const { result } = renderHook(() => useMutation(createUserMutation()), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.mutate({ data: userData });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.id).toBe(userData.username);
+  });
+});

--- a/src/restapi/users/add.ts
+++ b/src/restapi/users/add.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod';
+import { ApiRequestParams, apiRequest } from '../../API';
+import {
+  PloneClientConfig,
+  PloneClientConfigSchema,
+} from '../../interfaces/config';
+import {
+  User as CreateUserResponse,
+  createUserDataSchema,
+} from '../../interfaces/users';
+
+export const createUserArgsSchema = z.object({
+  data: createUserDataSchema,
+  config: PloneClientConfigSchema,
+});
+
+export type CreateUserArgs = z.infer<typeof createUserArgsSchema>;
+
+export const createUser = async ({
+  data,
+  config,
+}: CreateUserArgs): Promise<CreateUserResponse> => {
+  const validatedArgs = createUserArgsSchema.parse({
+    data,
+    config,
+  });
+
+  const options: ApiRequestParams = {
+    data: validatedArgs.data,
+    config: validatedArgs.config,
+  };
+
+  return apiRequest('post', '/@users', options);
+};
+
+export const createUserMutation = ({
+  config,
+}: {
+  config: PloneClientConfig;
+}) => ({
+  mutationKey: ['post', 'users'],
+  mutationFn: ({ data }: Omit<CreateUserArgs, 'config'>) =>
+    createUser({ data, config }),
+});

--- a/src/restapi/users/delete.test.tsx
+++ b/src/restapi/users/delete.test.tsx
@@ -1,0 +1,57 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { createWrapper } from '../../testUtils';
+import { useMutation } from '@tanstack/react-query';
+import { setup, teardown } from '../../resetFixture';
+import { beforeEach } from 'vitest';
+import { expect, test } from 'vitest';
+import PloneClient from '../../client';
+import { createUser } from './add';
+
+const cli = PloneClient.initialize({
+  apiPath: 'http://localhost:55001/plone',
+});
+
+const { login, deleteUserMutation } = cli;
+await login({ username: 'admin', password: 'secret' });
+
+beforeEach(async () => {
+  await setup();
+});
+
+afterEach(async () => {
+  await teardown();
+});
+
+describe('[DELETE] UserDelete', () => {
+  test('Hook - Successful', async () => {
+    const userData = {
+      username: 'deleteTestUser',
+      email: 'deleteTestUser@example.com',
+      password: 'password',
+    };
+
+    await createUser({ data: userData, config: cli.config });
+
+    const { result } = renderHook(() => useMutation(deleteUserMutation()), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.mutate({ userId: userData.username });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+
+  test('Hook - Failure', async () => {
+    const { result } = renderHook(() => useMutation(deleteUserMutation()), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.mutate({ userId: 'blah' });
+    });
+
+    await waitFor(() => expect(result.current.data).toBe(undefined));
+  });
+});

--- a/src/restapi/users/delete.ts
+++ b/src/restapi/users/delete.ts
@@ -1,0 +1,41 @@
+import { apiRequest, ApiRequestParams } from '../../API';
+import { z } from 'zod';
+import {
+  PloneClientConfig,
+  PloneClientConfigSchema,
+} from '../../interfaces/config';
+
+export const deleteUserArgsSchema = z.object({
+  userId: z.string(),
+  config: PloneClientConfigSchema,
+});
+
+type DeleteUserArgs = z.infer<typeof deleteUserArgsSchema>;
+
+export const deleteUser = async ({
+  userId,
+  config,
+}: DeleteUserArgs): Promise<undefined> => {
+  const validatedArgs = deleteUserArgsSchema.parse({
+    userId,
+    config,
+  });
+
+  const options: ApiRequestParams = {
+    config: validatedArgs.config,
+  };
+
+  const userName = `/@users/${validatedArgs.userId}`;
+
+  return apiRequest('delete', userName, options);
+};
+
+export const deleteUserMutation = ({
+  config,
+}: {
+  config: PloneClientConfig;
+}) => ({
+  mutationKey: ['delete', 'users'],
+  mutationFn: ({ userId }: Omit<DeleteUserArgs, 'config'>) =>
+    deleteUser({ userId, config }),
+});

--- a/src/restapi/users/get.test.tsx
+++ b/src/restapi/users/get.test.tsx
@@ -1,0 +1,66 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { createWrapper } from '../../testUtils';
+import { useQuery } from '@tanstack/react-query';
+import { setup, teardown } from '../../resetFixture';
+import { beforeEach } from 'vitest';
+import { expect, test } from 'vitest';
+import PloneClient from '../../client';
+import { createUser } from './add';
+import { v4 as uuid } from 'uuid';
+
+const cli = PloneClient.initialize({
+  apiPath: 'http://localhost:55001/plone',
+});
+
+const { login, getUserQuery } = cli;
+await login({ username: 'admin', password: 'secret' });
+
+beforeEach(async () => {
+  await setup();
+});
+
+afterEach(async () => {
+  await teardown();
+});
+
+describe('[GET] User', () => {
+  test('Hook - Successful', async () => {
+    const randomId = uuid();
+
+    const userData = {
+      username: `getTestUser${randomId}`,
+      email: `getTestUser${randomId}@example.com`,
+      password: 'password',
+    };
+
+    await createUser({ data: userData, config: cli.config });
+
+    const { result } = renderHook(
+      () => useQuery(getUserQuery({ userId: userData.username })),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.id).toBe(userData.username);
+  });
+
+  test('Hook - Failure', async () => {
+    const userData = {
+      username: 'getTestUserFail',
+      email: 'getTestUser@exampleFail.com',
+      password: 'password',
+    };
+
+    const { result } = renderHook(
+      () => useQuery(getUserQuery({ userId: userData.username })),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/src/restapi/users/get.ts
+++ b/src/restapi/users/get.ts
@@ -1,0 +1,34 @@
+import { apiRequest, ApiRequestParams } from '../../API';
+import { PloneClientConfig } from '../../interfaces/config';
+import { z } from 'zod';
+import { User as GetUserResponse } from '../../interfaces/users';
+
+const getUserSchema = z.object({
+  userId: z.string(),
+});
+
+export type UserArgs = z.infer<typeof getUserSchema> & {
+  config: PloneClientConfig;
+};
+
+export const getUser = async ({
+  userId,
+  config,
+}: UserArgs): Promise<GetUserResponse> => {
+  const validatedArgs = getUserSchema.parse({
+    userId,
+  });
+
+  const options: ApiRequestParams = {
+    config,
+    params: {},
+  };
+  const userName = `@users/${validatedArgs.userId}`;
+
+  return apiRequest('get', userName, options);
+};
+
+export const getUserQuery = ({ userId, config }: UserArgs) => ({
+  queryKey: [userId, 'get', 'users'],
+  queryFn: () => getUser({ userId, config }),
+});

--- a/src/restapi/users/get_list.test.tsx
+++ b/src/restapi/users/get_list.test.tsx
@@ -20,4 +20,30 @@ describe('[GET] UsersList', () => {
 
     expect(result.current.data?.[0]).toHaveProperty('@id');
   });
+
+  test('Hook - Successful - groupsFilter', async () => {
+    const { result } = renderHook(
+      () => useQuery(getUsersQuery({ groupsFilter: ['AuthenticatedUsers'] })),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.[0]).toHaveProperty('@id');
+  });
+
+  test('Hook - Successful - query', async () => {
+    const { result } = renderHook(
+      () => useQuery(getUsersQuery({ query: 'test_user_1_' })),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.[0]).toHaveProperty('@id');
+  });
 });

--- a/src/restapi/users/get_list.test.tsx
+++ b/src/restapi/users/get_list.test.tsx
@@ -1,0 +1,23 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { createWrapper } from '../../testUtils';
+import { useQuery } from '@tanstack/react-query';
+import ploneClient from '../../client';
+
+const cli = ploneClient.initialize({
+  apiPath: 'http://localhost:55001/plone',
+});
+
+const { login, getUsersQuery } = cli;
+await login({ username: 'admin', password: 'secret' });
+
+describe('[GET] UsersList', () => {
+  test('Hook - Successful', async () => {
+    const { result } = renderHook(() => useQuery(getUsersQuery({})), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.[0]).toHaveProperty('@id');
+  });
+});

--- a/src/restapi/users/get_list.ts
+++ b/src/restapi/users/get_list.ts
@@ -7,6 +7,7 @@ const getUsersSchema = z.object({
   query: z.string().optional(),
   groupsFilter: z.array(z.string()).optional(),
   search: z.string().optional(),
+  limit: z.number().optional(),
 });
 
 export type GetUsersArgs = z.infer<typeof getUsersSchema> & {
@@ -17,12 +18,14 @@ export const getUsers = async ({
   query,
   groupsFilter,
   search,
+  limit,
   config,
 }: GetUsersArgs): Promise<GetUsersResponse> => {
   const validatedArgs = getUsersSchema.parse({
     query,
     groupsFilter,
     search,
+    limit,
   });
 
   const options: ApiRequestParams = {
@@ -32,6 +35,7 @@ export const getUsers = async ({
       ...(validatedArgs.groupsFilter && {
         'groups-filter': validatedArgs.groupsFilter,
       }),
+      ...(validatedArgs.limit && { limit: validatedArgs.limit }),
       ...(validatedArgs.search && { search: validatedArgs.search }),
     },
   };
@@ -43,8 +47,9 @@ export const getUsersQuery = ({
   query,
   groupsFilter,
   search,
+  limit,
   config,
 }: GetUsersArgs) => ({
-  queryKey: [query, groupsFilter, search, 'get', 'users'],
-  queryFn: () => getUsers({ query, groupsFilter, search, config }),
+  queryKey: [query, groupsFilter, search, limit, 'get', 'users'],
+  queryFn: () => getUsers({ query, groupsFilter, search, limit, config }),
 });

--- a/src/restapi/users/get_list.ts
+++ b/src/restapi/users/get_list.ts
@@ -1,23 +1,50 @@
+import { z } from 'zod';
 import { apiRequest, ApiRequestParams } from '../../API';
 import { PloneClientConfig } from '../../interfaces/config';
 import { GetUsersResponse } from '../../interfaces/users';
 
-export type GetUsersArgs = {
+const getUsersSchema = z.object({
+  query: z.string().optional(),
+  groupsFilter: z.array(z.string()).optional(),
+  search: z.string().optional(),
+});
+
+export type GetUsersArgs = z.infer<typeof getUsersSchema> & {
   config: PloneClientConfig;
 };
 
 export const getUsers = async ({
+  query,
+  groupsFilter,
+  search,
   config,
 }: GetUsersArgs): Promise<GetUsersResponse> => {
+  const validatedArgs = getUsersSchema.parse({
+    query,
+    groupsFilter,
+    search,
+  });
+
   const options: ApiRequestParams = {
     config,
-    params: {},
+    params: {
+      ...(validatedArgs.query && { query: validatedArgs.query }),
+      ...(validatedArgs.groupsFilter && {
+        'groups-filter': validatedArgs.groupsFilter,
+      }),
+      ...(validatedArgs.search && { search: validatedArgs.search }),
+    },
   };
 
   return apiRequest('get', '/@users', options);
 };
 
-export const getUsersQuery = ({ config }: GetUsersArgs) => ({
-  queryKey: ['get', 'users'],
-  queryFn: () => getUsers({ config }),
+export const getUsersQuery = ({
+  query,
+  groupsFilter,
+  search,
+  config,
+}: GetUsersArgs) => ({
+  queryKey: [query, groupsFilter, search, 'get', 'users'],
+  queryFn: () => getUsers({ query, groupsFilter, search, config }),
 });

--- a/src/restapi/users/get_list.ts
+++ b/src/restapi/users/get_list.ts
@@ -1,0 +1,23 @@
+import { apiRequest, ApiRequestParams } from '../../API';
+import { PloneClientConfig } from '../../interfaces/config';
+import { GetUsersResponse } from '../../interfaces/users';
+
+export type GetUsersArgs = {
+  config: PloneClientConfig;
+};
+
+export const getUsers = async ({
+  config,
+}: GetUsersArgs): Promise<GetUsersResponse> => {
+  const options: ApiRequestParams = {
+    config,
+    params: {},
+  };
+
+  return apiRequest('get', '/@users', options);
+};
+
+export const getUsersQuery = ({ config }: GetUsersArgs) => ({
+  queryKey: ['get', 'users'],
+  queryFn: () => getUsers({ config }),
+});

--- a/src/restapi/users/reset_password.test.tsx
+++ b/src/restapi/users/reset_password.test.tsx
@@ -1,0 +1,47 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { createWrapper } from '../../testUtils';
+import { useMutation } from '@tanstack/react-query';
+import { setup, teardown } from '../../resetFixture';
+import { beforeEach } from 'vitest';
+import { expect, test } from 'vitest';
+import PloneClient from '../../client';
+import { getUniqueEntityName, loginWithCreate } from '../../utils/test';
+
+const cli = PloneClient.initialize({
+  apiPath: 'http://localhost:55001/plone',
+});
+
+const { login, resetPasswordMutation } = cli;
+await login({ username: 'admin', password: 'secret' });
+
+beforeEach(async () => {
+  await setup();
+});
+
+afterEach(async () => {
+  await teardown();
+});
+
+describe('[POST] PasswordReset', () => {
+  test('Hook - Successful', async () => {
+    const username = getUniqueEntityName('resetTestUser');
+    const userData = {
+      username,
+      email: `${username}@example.com`,
+      password: 'password',
+      roles: ['Site Administrator'],
+    };
+
+    await loginWithCreate(cli, userData);
+
+    const { result } = renderHook(() => useMutation(resetPasswordMutation()), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.mutate({ userId: username });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+});

--- a/src/restapi/users/reset_password.ts
+++ b/src/restapi/users/reset_password.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+import { ApiRequestParams, apiRequest } from '../../API';
+import {
+  PloneClientConfig,
+  PloneClientConfigSchema,
+} from '../../interfaces/config';
+
+export const resetPasswordArgsSchema = z.object({
+  userId: z.string(),
+  config: PloneClientConfigSchema,
+});
+
+export type ResetUserArgs = z.infer<typeof resetPasswordArgsSchema>;
+
+export const resetPassword = async ({
+  userId,
+  config,
+}: ResetUserArgs): Promise<undefined> => {
+  const validatedArgs = resetPasswordArgsSchema.parse({
+    userId,
+    config,
+  });
+
+  const options: ApiRequestParams = {
+    config: validatedArgs.config,
+  };
+
+  const userName = `@users/${validatedArgs.userId}/reset-password`;
+
+  return apiRequest('post', userName, options);
+};
+
+export const resetPasswordMutation = ({
+  config,
+}: {
+  config: PloneClientConfig;
+}) => ({
+  mutationKey: ['post', 'user'],
+  mutationFn: ({ userId }: Omit<ResetUserArgs, 'config'>) =>
+    resetPassword({ userId, config }),
+});

--- a/src/restapi/users/reset_password_with_token.ts
+++ b/src/restapi/users/reset_password_with_token.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod';
+import { ApiRequestParams, apiRequest } from '../../API';
+import {
+  PloneClientConfig,
+  PloneClientConfigSchema,
+} from '../../interfaces/config';
+import { resetPasswordWithTokenDataSchema } from '../../interfaces/users';
+
+export const resetPasswordWithTokenArgsSchema = z.object({
+  userId: z.string(),
+  data: resetPasswordWithTokenDataSchema,
+  config: PloneClientConfigSchema,
+});
+
+export type ResetPasswordWithTokenUserArgs = z.infer<
+  typeof resetPasswordWithTokenArgsSchema
+>;
+
+export const resetPasswordWithToken = async ({
+  userId,
+  data,
+  config,
+}: ResetPasswordWithTokenUserArgs): Promise<undefined> => {
+  const validatedArgs = resetPasswordWithTokenArgsSchema.parse({
+    userId,
+    data,
+    config,
+  });
+
+  const options: ApiRequestParams = {
+    data: validatedArgs.data,
+    config: validatedArgs.config,
+  };
+
+  const userName = `@users/${validatedArgs.userId}/reset-password`;
+
+  return apiRequest('post', userName, options);
+};
+
+export const resetPasswordWithTokenMutation = ({
+  config,
+}: {
+  config: PloneClientConfig;
+}) => ({
+  mutationKey: ['post', 'user'],
+  mutationFn: ({
+    userId,
+    data,
+  }: Omit<ResetPasswordWithTokenUserArgs, 'config'>) =>
+    resetPasswordWithToken({ userId, data, config }),
+});

--- a/src/restapi/users/update.test.tsx
+++ b/src/restapi/users/update.test.tsx
@@ -1,0 +1,200 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { createWrapper } from '../../testUtils';
+import { useMutation } from '@tanstack/react-query';
+import { setup, teardown } from '../../resetFixture';
+import { beforeEach } from 'vitest';
+import { expect, test } from 'vitest';
+import PloneClient from '../../client';
+import { createUser } from './add';
+import { getUser } from './get';
+import { v4 as uuid } from 'uuid';
+
+const cli = PloneClient.initialize({
+  apiPath: 'http://localhost:55001/plone',
+});
+
+const { login, updateUserMutation } = cli;
+await login({ username: 'admin', password: 'secret' });
+
+beforeEach(async () => {
+  await setup();
+});
+
+afterEach(async () => {
+  await teardown();
+});
+
+describe('[PATCH] UserUpdate', () => {
+  test('Hook - Successful', async () => {
+    const randomId = uuid();
+
+    const userData = {
+      username: `updateTestUser${randomId}`,
+      email: `updateTestUser${randomId}@example.com`,
+      password: 'password',
+    };
+
+    const updateUserData = {
+      username: 'changedUsername',
+    };
+
+    await createUser({ data: userData, config: cli.config });
+
+    const { result } = renderHook(() => useMutation(updateUserMutation()), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.mutate({
+        userId: userData.username,
+        data: updateUserData,
+      });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const user = await getUser({
+      userId: userData.username,
+      config: cli.config,
+    });
+
+    expect(user.username).toBe('changedUsername');
+  });
+
+  test('Hook - Successful - potrait', async () => {
+    const randomId = uuid().replace(/-/g, '');
+    // We need to remove hyphens because the user portrait field replaces each hyphen in userId with double hyphens
+
+    const userData = {
+      username: `updateTestUser${randomId}`,
+      email: `updateTestUser${randomId}@example.com`,
+      password: 'password',
+    };
+
+    const updatePortraitData = {
+      portrait: {
+        'content-type': 'image/gif',
+        data: 'R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=',
+        encoding: 'base64',
+        filename: 'image.gif',
+      },
+    };
+
+    await createUser({ data: userData, config: cli.config });
+
+    const { result } = renderHook(() => useMutation(updateUserMutation()), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.mutate({
+        userId: userData.username,
+        data: updatePortraitData,
+      });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const user = await getUser({
+      userId: userData.username,
+      config: cli.config,
+    });
+
+    expect(user.portrait).toBe(
+      `http://localhost:55001/plone/@portrait/${userData.username}`,
+    );
+  });
+
+  test('Hook - Successful - potrait & scale', async () => {
+    const randomId = uuid().replace(/-/g, '');
+    // We need to remove hyphens because the user portrait field replaces each hyphen in userId with double hyphens
+
+    const userData = {
+      username: `updateTestUser${randomId}`,
+      email: `updateTestUser${randomId}@example.com`,
+      password: 'password',
+    };
+
+    const updatePortraitData = {
+      portrait: {
+        'content-type': 'image/gif',
+        data: 'R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=',
+        encoding: 'base64',
+        filename: 'image.gif',
+        scale: true,
+      },
+    };
+
+    await createUser({ data: userData, config: cli.config });
+
+    const { result } = renderHook(() => useMutation(updateUserMutation()), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.mutate({
+        userId: userData.username,
+        data: updatePortraitData,
+      });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const user = await getUser({
+      userId: userData.username,
+      config: cli.config,
+    });
+
+    expect(user.portrait).toBe(
+      `http://localhost:55001/plone/@portrait/${userData.username}`,
+    );
+  });
+
+  test('Hook - Successful - username & portrait', async () => {
+    const randomId = uuid().replace(/-/g, '');
+    // We need to remove hyphens because the user portrait field replaces each hyphen in userId with double hyphens
+
+    const userData = {
+      username: `updateTestUser${randomId}`,
+      email: `updateTestUser${randomId}@example.com`,
+      password: 'password',
+    };
+
+    const updateUserData = {
+      username: 'changedUsername',
+      portrait: {
+        'content-type': 'image/gif',
+        data: 'R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=',
+        encoding: 'base64',
+        filename: 'image.gif',
+        scale: true,
+      },
+    };
+
+    await createUser({ data: userData, config: cli.config });
+
+    const { result } = renderHook(() => useMutation(updateUserMutation()), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.mutate({
+        userId: userData.username,
+        data: updateUserData,
+      });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const user = await getUser({
+      userId: userData.username,
+      config: cli.config,
+    });
+
+    expect(user.username).toBe(updateUserData.username);
+    expect(user.portrait).toBe(
+      `http://localhost:55001/plone/@portrait/${userData.username}`,
+    );
+  });
+  // TODO: Find correct implementation for failure test, currently no error is returned on updating non existing user
+});

--- a/src/restapi/users/update.ts
+++ b/src/restapi/users/update.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+import { apiRequest, ApiRequestParams } from '../../API';
+import {
+  PloneClientConfig,
+  PloneClientConfigSchema,
+} from '../../interfaces/config';
+import { updateUserDataSchema } from '../../interfaces/users';
+
+export const updateUserArgsSchema = z.object({
+  userId: z.string(),
+  data: updateUserDataSchema,
+  config: PloneClientConfigSchema,
+});
+
+export type UpdateUserArgs = z.infer<typeof updateUserArgsSchema>;
+
+export const updateUser = async ({
+  userId,
+  data,
+  config,
+}: UpdateUserArgs): Promise<undefined> => {
+  const validatedArgs = updateUserArgsSchema.parse({
+    userId,
+    data,
+    config,
+  });
+
+  const options: ApiRequestParams = {
+    data: validatedArgs.data,
+    config: validatedArgs.config,
+  };
+
+  const userName = `/@users/${validatedArgs.userId}`;
+
+  return apiRequest('patch', userName, options);
+};
+
+export const updateUserMutation = ({
+  config,
+}: {
+  config: PloneClientConfig;
+}) => ({
+  mutationKey: ['patch', 'users'],
+  mutationFn: ({ userId, data }: Omit<UpdateUserArgs, 'config'>) =>
+    updateUser({ userId, data, config }),
+});

--- a/src/restapi/users/update_password.test.tsx
+++ b/src/restapi/users/update_password.test.tsx
@@ -1,0 +1,52 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { createWrapper } from '../../testUtils';
+import { useMutation } from '@tanstack/react-query';
+import { setup, teardown } from '../../resetFixture';
+import { beforeEach } from 'vitest';
+import { expect, test } from 'vitest';
+import PloneClient from '../../client';
+import { getUniqueEntityName, loginWithCreate } from '../../utils/test';
+
+const cli = PloneClient.initialize({
+  apiPath: 'http://localhost:55001/plone',
+});
+
+const { login, updatePasswordMutation } = cli;
+await login({ username: 'admin', password: 'secret' });
+
+beforeEach(async () => {
+  await setup();
+});
+
+afterEach(async () => {
+  await teardown();
+});
+
+describe('[POST] PasswordUpdate', () => {
+  test('Hook - Successful', async () => {
+    const username = getUniqueEntityName('resetTestUser');
+    const userData = {
+      username,
+      email: `${username}@example.com`,
+      password: 'password',
+      roles: ['Site Administrator'],
+    };
+
+    await loginWithCreate(cli, userData);
+
+    const { result } = renderHook(() => useMutation(updatePasswordMutation()), {
+      wrapper: createWrapper(),
+    });
+
+    const resetUserData = {
+      old_password: 'password',
+      new_password: 'changedpassword',
+    };
+
+    act(() => {
+      result.current.mutate({ userId: username, data: resetUserData });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+});

--- a/src/restapi/users/update_password.ts
+++ b/src/restapi/users/update_password.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+import { ApiRequestParams, apiRequest } from '../../API';
+import {
+  PloneClientConfig,
+  PloneClientConfigSchema,
+} from '../../interfaces/config';
+import { updatePasswordDataSchema } from '../../interfaces/users';
+
+export const updatePasswordArgsSchema = z.object({
+  userId: z.string(),
+  data: updatePasswordDataSchema,
+  config: PloneClientConfigSchema,
+});
+
+export type UpdatePasswordArgs = z.infer<typeof updatePasswordArgsSchema>;
+
+export const updatePassword = async ({
+  userId,
+  data,
+  config,
+}: UpdatePasswordArgs): Promise<undefined> => {
+  const validatedArgs = updatePasswordArgsSchema.parse({
+    userId,
+    data,
+    config,
+  });
+
+  const options: ApiRequestParams = {
+    data: validatedArgs.data,
+    config: validatedArgs.config,
+  };
+
+  const userName = `@users/${validatedArgs.userId}/reset-password`;
+
+  return apiRequest('post', userName, options);
+};
+
+export const updatePasswordMutation = ({
+  config,
+}: {
+  config: PloneClientConfig;
+}) => ({
+  mutationKey: ['post', 'user'],
+  mutationFn: ({ userId, data }: Omit<UpdatePasswordArgs, 'config'>) =>
+    updatePassword({ userId, data, config }),
+});

--- a/src/utils/test.ts
+++ b/src/utils/test.ts
@@ -1,9 +1,45 @@
+import PloneClient from '../client';
+import { createUser } from '../restapi/users/add';
 import { v4 as uuid } from 'uuid';
 
-export const getUniqueEntityName = (baseName: string) => `${baseName}${uuid()}`;
+export const loginWithCreate = async (
+  cli: PloneClient,
+  {
+    username,
+    password,
+    email,
+    roles,
+  }: {
+    username: string;
+    email?: string;
+    password: string;
+    roles?: string[];
+  },
+) => {
+  if (!email) {
+    return cli.login({ username, password });
+  }
+
+  try {
+    await createUser({
+      data: { username, password, email, roles },
+      config: cli.config,
+    });
+  } catch (e) {
+    // handle error if the user has already been creatd in previous invocations
+  }
+
+  return cli.login({ username, password });
+};
+
+export const getUniqueEntityName = (baseName: string) =>
+  `${baseName}${uuid().replaceAll('-', '')}`;
 
 export const stripExtraSlash = (path: string) => {
   const pathSegments = path.split('/').filter((segment) => segment !== ''); // Split path and remove empty segments
   const cleanedPath = '/' + pathSegments.join('/'); // Rejoin the path segments with a single slash
   return cleanedPath;
 };
+
+export const getPathFromPageTitle = (title: string) =>
+  stripExtraSlash(`/${title.toLocaleLowerCase().split(' ').join('-')}`);

--- a/testRunner.js
+++ b/testRunner.js
@@ -1,0 +1,54 @@
+import fs from 'fs';
+import glob from 'glob';
+import { execSync } from 'child_process';
+
+// get directories in src
+const directories = fs
+  .readdirSync('./src/restapi', { withFileTypes: true })
+  .filter((dirent) => dirent.isDirectory())
+  .map((dirent) => dirent.name);
+
+/*
+  For each directory, run vitest sequentially.
+
+  This is done to make sure that the tests are isolated from which other.
+  
+  Using no-threads parameter removes the per-module isolation as well, but 
+  not using the no-threads parameter causes tests to fail beccause there
+  is no isolation at the test DB level and different tests can interefere
+  with each other's mutations.
+*/
+
+directories.forEach((dir) => {
+  glob(`./src/${dir}/*/.test.tsx`, (err, matches) => {
+    if (err) {
+      console.error(err);
+      return;
+    }
+
+    // if there are any matches, run vitest on this directory
+    if (matches.length > 0) {
+      console.log(`Running vitest on src/${dir}`);
+      execSync(`yarn vitest "src/${dir}/*/.test.{ts,tsx,js,jsx}"`, {
+        stdio: 'inherit',
+      });
+    }
+  });
+});
+
+directories.forEach((dir) => {
+  glob(`./src/restapi/${dir}/**/*.test.tsx`, (err, matches) => {
+    if (err) {
+      console.error(err);
+      throw Error(err);
+    }
+
+    // if there are any matches, run vitest on this directory
+    if (matches.length > 0) {
+      console.log(`Running vitest on src/${dir}`);
+      execSync(`yarn vitest run src/restapi/${dir} --no-threads`, {
+        stdio: 'inherit',
+      });
+    }
+  });
+});


### PR DESCRIPTION
This PR introduces:

3 more services namely groups, history and users along with their tests and associated types.

Other changes:

1. use loginCreate to login into a user if it has been already created, and create the user first in case there's no user by that username. 
2. use getPathFromPageTitle to convert a string to hyphenated case.
3. added testRunner file to run the tests in islolation from each other.


