### PR TITLE
Introducing hooks for actions

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -11,13 +11,11 @@ Once imported, you should call `initialize` to setup its basic parameters.
 
 After initialization, you can import all the pre-made query factories.
 
-
-
 ```ts
-import ploneClient from "@plone/client";
+import ploneClient from '@plone/client';
 
 const client = ploneClient.initialize({
-  apiPath: "http://localhost:8080/Plone",
+  apiPath: 'http://localhost:8080/Plone',
 });
 ```
 
@@ -36,12 +34,12 @@ The query factories take an object as configuration. These object has some commo
 These is the complete example of the usage of the client in a React client component:
 
 ```jsx
-import { useQuery } from "@tanstack/react-query";
-import ploneClient from "@plone/client";
-import { usePathname } from "next/navigation";
+import { useQuery } from '@tanstack/react-query';
+import ploneClient from '@plone/client';
+import { usePathname } from 'next/navigation';
 
 const client = ploneClient.initialize({
-  apiPath: "http://localhost:8080/Plone",
+  apiPath: 'http://localhost:8080/Plone',
 });
 
 export default function Title() {
@@ -50,7 +48,7 @@ export default function Title() {
   const { data, isLoading } = useQuery(getContentQuery({ path: pathname }));
 
   if (isLoading) {
-    return <div>Loading...</div>
+    return <div>Loading...</div>;
   }
 
   if (data) {
@@ -61,6 +59,16 @@ export default function Title() {
     );
   }
 
-  return "";
+  return '';
 }
+```
+
+## Hooks
+
+We have provided custom hooks for actions that can be used directly in functional React components.
+
+```ts
+const { useGetContent } = client;
+
+const { data, isLoading } = useGetContent({ path: pathname });
 ```

--- a/news/33.feature
+++ b/news/33.feature
@@ -1,0 +1,1 @@
+Add custom hooks for all the actions @hemant-hc

--- a/src/client.ts
+++ b/src/client.ts
@@ -580,12 +580,9 @@ export default class PloneClient {
   useGetAliases = queryHookFromQuery(this.getAliasesQuery);
   useCreateAliases = mutationHookFromMutation(this.createAliasesMutation);
   useDeleteAliases = mutationHookFromMutation(this.deleteAliasesMutation);
-  useGetAliasesRoot = queryHookFromQuery(this.getAliasesRootQuery);
-  useCreateAliasesRoot = mutationHookFromMutation(
-    this.createAliasesRootMutation,
-  );
-  useDeleteAliasesRoot = mutationHookFromMutation(
-    this.deleteAliasesRootMutation,
+  useGetAliasesList = queryHookFromQuery(this.getAliasesListQuery);
+  useCreateAliasesMultiple = mutationHookFromMutation(
+    this.createAliasesMultipleMutation,
   );
 
   /*
@@ -633,4 +630,169 @@ export default class PloneClient {
   );
   useUpdatePassword = mutationHookFromMutation(this.updatePasswordMutation);
   useUpdateUser = mutationHookFromMutation(this.updateUserMutation);
+
+  /*
+    Relations hooks
+  */
+  useGetRelationsList = queryHookFromQuery(this.getRelationsListQuery);
+  useGetRelations = queryHookFromQuery(this.getRelationsQuery);
+  useCreateRelations = mutationHookFromMutation(this.createRelationsMutation);
+  useDeleteRelations = mutationHookFromMutation(this.deleteRelationsMutation);
+  useFixRelations = mutationHookFromMutation(this.fixRelationsMutation);
+
+  /*
+    UserSchema hooks
+  */
+  useGetUserschema = queryHookFromQuery(this.getUserschemaQuery);
+
+  /*
+    Roles hooks
+  */
+  useGetRoles = queryHookFromQuery(this.getRolesQuery);
+
+  /*
+    System hooks
+  */
+  useGetSystem = queryHookFromQuery(this.getSystemQuery);
+
+  /*
+    Transactions hooks
+  */
+  useGetTransactions = queryHookFromQuery(this.getTransactionsQuery);
+  useRevertTransactions = mutationHookFromMutation(
+    this.revertTransactionsMutation,
+  );
+
+  /*
+    Principals hooks
+  */
+  useGetPrincipals = queryHookFromQuery(this.getPrincipalsQuery);
+
+  /*
+    Workingcopy hooks
+  */
+  useGetWorkingcopy = queryHookFromQuery(this.getWorkingcopyQuery);
+  useCreateWorkingcopy = mutationHookFromMutation(
+    this.createWorkingcopyMutation,
+  );
+  useCheckInWorkingcopy = mutationHookFromMutation(
+    this.checkInWorkingcopyMutation,
+  );
+  useDeleteWorkingcopy = mutationHookFromMutation(
+    this.deleteWorkingcopyMutation,
+  );
+
+  /*
+    Querystring search hooks
+  */
+  useGetQuerystringSearch = queryHookFromQuery(this.getQuerystringSearchQuery);
+  usePostQuerystringSearch = mutationHookFromMutation(
+    this.postQuerystringSearchMutation,
+  );
+
+  /*
+    Rules hooks
+  */
+  useGetRules = queryHookFromQuery(this.getRulesQuery);
+  useCreateRule = mutationHookFromMutation(this.createRuleMutation);
+  useUpdateRules = mutationHookFromMutation(this.updateRulesMutation);
+  useDeleteRules = mutationHookFromMutation(this.deleteRulesMutation);
+
+  /*
+    Controlpanels hooks
+  */
+  useGetControlpanels = queryHookFromQuery(this.getControlpanelsQuery);
+  useGetControlpanel = queryHookFromQuery(this.getControlpanelQuery);
+  useCreateControlpanel = mutationHookFromMutation(
+    this.createControlpanelMutation,
+  );
+  useUpdateControlpanel = mutationHookFromMutation(
+    this.updateControlpanelMutation,
+  );
+  useDeleteControlpanel = mutationHookFromMutation(
+    this.deleteControlpanelMutation,
+  );
+
+  /*
+    Search hooks
+  */
+  useGetSearch = queryHookFromQuery(this.getSearchQuery);
+
+  /*
+    Querysources hooks
+  */
+  useGetQuerysource = queryHookFromQuery(this.getQuerysourceQuery);
+
+  /*
+    Sources hooks
+  */
+  useGetSource = queryHookFromQuery(this.getSourceQuery);
+
+  /*
+    Copy and Move hooks
+  */
+  useCopy = mutationHookFromMutation(this.copyMutation);
+  useMove = mutationHookFromMutation(this.moveMutation);
+
+  /*
+    Site hooks
+  */
+  useGetSite = queryHookFromQuery(this.getSiteQuery);
+
+  /*
+    Registries hooks
+  */
+  useGetRegistries = queryHookFromQuery(this.getRegistriesQuery);
+  useGetRegistry = queryHookFromQuery(this.getRegistryQuery);
+  useUpdateRegistry = mutationHookFromMutation(this.updateRegistryMutation);
+
+  /*
+    Upgrade hooks
+  */
+  useGetUpgrade = queryHookFromQuery(this.getUpgradeQuery);
+  useRunUpgrade = mutationHookFromMutation(this.runUpgradeMutation);
+
+  /*
+    Linkintegrity hooks
+  */
+  useGetLinkintegrity = queryHookFromQuery(this.getLinkintegrityQuery);
+
+  /*
+    Lock hooks
+  */
+  useGetLock = queryHookFromQuery(this.getLockQuery);
+  useCreateLock = mutationHookFromMutation(this.createLockMutation);
+  useUpdateLock = mutationHookFromMutation(this.updateLockMutation);
+  useDeleteLock = mutationHookFromMutation(this.deleteLockMutation);
+
+  /*
+    Workflow hooks
+  */
+  useGetWorkflow = queryHookFromQuery(this.getWorkflowQuery);
+  useCreateWorkflow = mutationHookFromMutation(this.createWorkflowMutation);
+
+  /*
+    Vocabularies hooks
+  */
+  useGetVocabulariesList = queryHookFromQuery(this.getVocabulariesListQuery);
+  useGetVocabularies = queryHookFromQuery(this.getVocabulariesQuery);
+
+  /*
+    Querystring hooks
+  */
+  useGetQueryString = queryHookFromQuery(this.getQueryStringQuery);
+
+  /*
+    Navroot hooks
+  */
+  useGetNavroot = queryHookFromQuery(this.getNavrootQuery);
+
+  /*
+    Type hooks
+  */
+  useGetTypes = queryHookFromQuery(this.getTypesQuery);
+  useGetType = queryHookFromQuery(this.getTypeQuery);
+  useGetTypeField = queryHookFromQuery(this.getTypeFieldQuery);
+  useCreateTypeField = mutationHookFromMutation(this.createTypeFieldMutation);
+  useUpdateTypeField = mutationHookFromMutation(this.updateTypeFieldMutation);
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -795,4 +795,33 @@ export default class PloneClient {
   useGetTypeField = queryHookFromQuery(this.getTypeFieldQuery);
   useCreateTypeField = mutationHookFromMutation(this.createTypeFieldMutation);
   useUpdateTypeField = mutationHookFromMutation(this.updateTypeFieldMutation);
+
+  /*
+    Comments hooks
+  */
+  useGetComments = queryHookFromQuery(this.getCommentsQuery);
+  useCreateComment = mutationHookFromMutation(this.createCommentMutation);
+  useUpdateComment = mutationHookFromMutation(this.updateCommentMutation);
+  useDeleteComment = mutationHookFromMutation(this.deleteCommentMutation);
+
+  /*
+    Email notifcation hooks
+  */
+  useEmailNotification = mutationHookFromMutation(
+    this.emailNotificationMutation,
+  );
+
+  /*
+    Email send hooks
+  */
+  useEmailSend = mutationHookFromMutation(this.emailSendMutation);
+
+  /*
+    Translation hooks
+  */
+  useGetTranslation = queryHookFromQuery(this.getTranslationQuery);
+  useLinkTranslation = mutationHookFromMutation(this.linkTranslationMutation);
+  useUnlinkTranslation = mutationHookFromMutation(
+    this.unlinkTranslationMutation,
+  );
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -103,7 +103,12 @@ import { getTranslationQuery as _getTranslationQuery } from './restapi/translati
 import { linkTranslationMutation as _linkTranslationMutation } from './restapi/translations/link';
 import { unlinkTranslationMutation as _unlinkTranslationMutation } from './restapi/translations/unlink';
 
-import { mutationWithConfig, queryWithConfig } from './utils/misc';
+import {
+  queryHookFromQuery,
+  mutationWithConfig,
+  queryWithConfig,
+  mutationHookFromMutation,
+} from './utils/misc';
 import { PloneClientConfig } from './interfaces/config';
 
 const PLONECLIENT_DEFAULT_CONFIG = { apiPath: 'http://localhost:8080/Plone' };
@@ -536,4 +541,96 @@ export default class PloneClient {
     _unlinkTranslationMutation,
     this.getConfig,
   );
+
+  /*
+    Actions hooks
+  */
+
+  /*
+    Content hooks
+  */
+  useGetContent = queryHookFromQuery(this.getContentQuery);
+  useCreateContent = mutationHookFromMutation(this.createContentMutation);
+  useUpdateContent = mutationHookFromMutation(this.updateContentMutation);
+  useDeleteContent = mutationHookFromMutation(this.deleteContentMutation);
+
+  /*
+    Breadcrumbs hooks
+  */
+  useGetBreadcrumbs = queryHookFromQuery(this.getBreadcrumbsQuery);
+
+  /*
+    Navigation hooks
+  */
+  useGetNavigation = queryHookFromQuery(this.getNavigationQuery);
+
+  /*
+    ContextNavigation hooks
+  */
+  useGetContextNavigation = queryHookFromQuery(this.getContextNavigationQuery);
+
+  /*
+    Actions hooks
+  */
+  useGetActions = queryHookFromQuery(this.getActionsQuery);
+
+  /*
+    Aliases hooks
+  */
+  useGetAliases = queryHookFromQuery(this.getAliasesQuery);
+  useCreateAliases = mutationHookFromMutation(this.createAliasesMutation);
+  useDeleteAliases = mutationHookFromMutation(this.deleteAliasesMutation);
+  useGetAliasesRoot = queryHookFromQuery(this.getAliasesRootQuery);
+  useCreateAliasesRoot = mutationHookFromMutation(
+    this.createAliasesRootMutation,
+  );
+  useDeleteAliasesRoot = mutationHookFromMutation(
+    this.deleteAliasesRootMutation,
+  );
+
+  /*
+    Addons hooks
+  */
+  useGetAddons = queryHookFromQuery(this.getAddonsQuery);
+  useGetAddon = queryHookFromQuery(this.getAddonQuery);
+  useInstallAddon = mutationHookFromMutation(this.installAddonMutation);
+  useInstallProfileAddon = mutationHookFromMutation(
+    this.installProfileAddonMutation,
+  );
+  useUninstallAddon = mutationHookFromMutation(this.uninstallAddonMutation);
+  useUpgradeAddon = mutationHookFromMutation(this.upgradeAddonMutation);
+
+  /*
+    Database hooks
+  */
+  useGetDatabase = queryHookFromQuery(this.getDatabaseQuery);
+
+  /*
+    Group hooks
+  */
+  useGetGroups = queryHookFromQuery(this.getGroupsQuery);
+  useGetGroup = queryHookFromQuery(this.getGroupQuery);
+  useCreateGroup = mutationHookFromMutation(this.createGroupMutation);
+  useUpdateGroup = mutationHookFromMutation(this.updateGroupMutation);
+  useDeleteGroup = mutationHookFromMutation(this.deleteGroupMutation);
+
+  /*
+    History hooks
+  */
+  useGetHistory = queryHookFromQuery(this.getHistoryQuery);
+  useGetHistoryVersioned = queryHookFromQuery(this.getHistoryVersionedQuery);
+
+  /*
+    User hooks
+  */
+  useGetUsers = queryHookFromQuery(this.getUsersQuery);
+  useGetUser = queryHookFromQuery(this.getUserQuery);
+  useCreateUser = mutationHookFromMutation(this.createUserMutation);
+  useDeleteUser = mutationHookFromMutation(this.deleteUserMutation);
+  useResetPassword = mutationHookFromMutation(this.resetPasswordMutation);
+  useResetPasswordWithToken = mutationHookFromMutation(
+    this.resetPasswordWithTokenMutation,
+  );
+  useUpdatePassword = mutationHookFromMutation(this.updatePasswordMutation);
+  useUpdateUser = mutationHookFromMutation(this.updateUserMutation);
 }

--- a/src/restapi/content/add.test.tsx
+++ b/src/restapi/content/add.test.tsx
@@ -11,7 +11,7 @@ const cli = PloneClient.initialize({
   apiPath: 'http://localhost:55001/plone',
 });
 
-const { login, createContentMutation } = cli;
+const { login, createContentMutation, useCreateContent } = cli;
 await login({ username: 'admin', password: 'secret' });
 
 beforeEach(async () => {
@@ -53,7 +53,7 @@ describe('[POST] Content', () => {
       title: 'My Page',
     };
 
-    const { result } = renderHook(() => useMutation(createContentMutation()), {
+    const { result } = renderHook(useCreateContent, {
       wrapper: createWrapper(),
     });
 

--- a/src/restapi/content/get.test.tsx
+++ b/src/restapi/content/get.test.tsx
@@ -7,8 +7,7 @@ import { apiRequest } from '../../API';
 const cli = ploneClient.initialize({
   apiPath: 'http://localhost:55001/plone',
 });
-
-const { getContentQuery } = cli;
+const { getContentQuery, useGetContent } = cli;
 
 describe('[GET] Content', () => {
   test('Hook - Successful', async () => {
@@ -36,12 +35,9 @@ describe('[GET] Content', () => {
   test('Hook - fullobjects', async () => {
     const path = '/';
     const fullObjects = true;
-    const { result } = renderHook(
-      () => useQuery(getContentQuery({ path, fullObjects })),
-      {
-        wrapper: createWrapper(),
-      },
-    );
+    const { result } = renderHook(() => useGetContent({ path, fullObjects }), {
+      wrapper: createWrapper(),
+    });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 

--- a/src/utils/misc.test.tsx
+++ b/src/utils/misc.test.tsx
@@ -1,0 +1,52 @@
+import { test } from 'vitest';
+import { mutationHookFromMutation, queryHookFromQuery } from './misc';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { createWrapper } from '../testUtils';
+
+test('queryHookFromQuery should return expected result', async () => {
+  const mockQueryFn = vi.fn(() => Promise.resolve('mockData'));
+
+  const mockQueryFnCreator = vi.fn(() => ({
+    queryKey: ['mockQuery'],
+    queryFn: mockQueryFn,
+  }));
+
+  const queryHook = queryHookFromQuery(mockQueryFnCreator);
+
+  const { result } = renderHook(() => queryHook({}), {
+    wrapper: createWrapper(),
+  });
+
+  await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+  expect(mockQueryFnCreator).toHaveBeenCalled();
+  expect(mockQueryFn).toHaveBeenCalledOnce();
+
+  expect(result.current?.data).toBe('mockData');
+});
+
+test('mutationHookFromMutation should return expected result', async () => {
+  const mockMutationFn = vi.fn(() => Promise.resolve('mockData'));
+
+  const mockMutationFnCreator = vi.fn(() => ({
+    mutationKey: ['mockMutation'],
+    mutationFn: mockMutationFn,
+  }));
+
+  const mutationHook = mutationHookFromMutation(mockMutationFnCreator);
+
+  const { result } = renderHook(mutationHook, {
+    wrapper: createWrapper(),
+  });
+
+  act(() => {
+    result.current.mutate({});
+  });
+
+  await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+  expect(mockMutationFnCreator).toHaveBeenCalled();
+  expect(mockMutationFn).toHaveBeenCalledOnce();
+
+  expect(result.current?.data).toBe('mockData');
+});

--- a/src/utils/misc.test.tsx
+++ b/src/utils/misc.test.tsx
@@ -3,50 +3,52 @@ import { mutationHookFromMutation, queryHookFromQuery } from './misc';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { createWrapper } from '../testUtils';
 
-test('queryHookFromQuery should return expected result', async () => {
-  const mockQueryFn = vi.fn(() => Promise.resolve('mockData'));
+describe('hook creator functions', () => {
+  test('queryHookFromQuery should return expected result', async () => {
+    const mockQueryFn = vi.fn(() => Promise.resolve('mockData'));
 
-  const mockQueryFnCreator = vi.fn(() => ({
-    queryKey: ['mockQuery'],
-    queryFn: mockQueryFn,
-  }));
+    const mockQueryFnCreator = vi.fn(() => ({
+      queryKey: ['mockQuery'],
+      queryFn: mockQueryFn,
+    }));
 
-  const queryHook = queryHookFromQuery(mockQueryFnCreator);
+    const queryHook = queryHookFromQuery(mockQueryFnCreator);
 
-  const { result } = renderHook(() => queryHook({}), {
-    wrapper: createWrapper(),
+    const { result } = renderHook(() => queryHook({}), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockQueryFnCreator).toHaveBeenCalled();
+    expect(mockQueryFn).toHaveBeenCalledOnce();
+
+    expect(result.current?.data).toBe('mockData');
   });
 
-  await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  test('mutationHookFromMutation should return expected result', async () => {
+    const mockMutationFn = vi.fn(() => Promise.resolve('mockData'));
 
-  expect(mockQueryFnCreator).toHaveBeenCalled();
-  expect(mockQueryFn).toHaveBeenCalledOnce();
+    const mockMutationFnCreator = vi.fn(() => ({
+      mutationKey: ['mockMutation'],
+      mutationFn: mockMutationFn,
+    }));
 
-  expect(result.current?.data).toBe('mockData');
-});
+    const mutationHook = mutationHookFromMutation(mockMutationFnCreator);
 
-test('mutationHookFromMutation should return expected result', async () => {
-  const mockMutationFn = vi.fn(() => Promise.resolve('mockData'));
+    const { result } = renderHook(mutationHook, {
+      wrapper: createWrapper(),
+    });
 
-  const mockMutationFnCreator = vi.fn(() => ({
-    mutationKey: ['mockMutation'],
-    mutationFn: mockMutationFn,
-  }));
+    act(() => {
+      result.current.mutate({});
+    });
 
-  const mutationHook = mutationHookFromMutation(mockMutationFnCreator);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-  const { result } = renderHook(mutationHook, {
-    wrapper: createWrapper(),
+    expect(mockMutationFnCreator).toHaveBeenCalled();
+    expect(mockMutationFn).toHaveBeenCalledOnce();
+
+    expect(result.current?.data).toBe('mockData');
   });
-
-  act(() => {
-    result.current.mutate({});
-  });
-
-  await waitFor(() => expect(result.current.isSuccess).toBe(true));
-
-  expect(mockMutationFnCreator).toHaveBeenCalled();
-  expect(mockMutationFn).toHaveBeenCalledOnce();
-
-  expect(result.current?.data).toBe('mockData');
 });

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -58,6 +58,10 @@ type TReturnType<T> = T extends (args: any) => infer U ? U : never;
   `useMutation` directly.
 */
 
+type TArguments<T> = T extends (args: infer U) => any ? U : never;
+
+type TReturnType<T> = T extends (args: any) => infer U ? U : never;
+
 type TQueryFnReturnType<T> = T extends { queryFn: () => Promise<infer U> }
   ? U
   : never;

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -1,3 +1,9 @@
+import {
+  UseMutationResult,
+  UseQueryResult,
+  useMutation,
+  useQuery,
+} from '@tanstack/react-query';
 import { PloneClientConfig } from '../interfaces/config';
 
 /*
@@ -37,4 +43,53 @@ export const flattenToDottedNotation = (
   }
 
   return result;
+};
+
+type TArguments<T> = T extends (args: infer U) => any ? U : never;
+
+type TReturnType<T> = T extends (args: any) => infer U ? U : never;
+
+/*
+  `queryHookFromQuery` and `mutationHookFromMutation` functions can be used to 
+  create hooks from the query functions and mutation functions respectively. It 
+  takes a query function or a mutation function and returns a hook function.The
+  hook function is returned with appropriate type casting. They use useQuery and 
+  useMutation internally so that the user doesn't have to use `useQuery` or 
+  `useMutation` directly.
+*/
+
+type TQueryFnReturnType<T> = T extends { queryFn: () => Promise<infer U> }
+  ? U
+  : never;
+
+export const queryHookFromQuery = <T extends (...args: any) => any>(
+  queryFnCreator: T,
+) => {
+  return (args: TArguments<typeof queryFnCreator>) =>
+    useQuery(queryFnCreator(args)) as UseQueryResult<
+      TQueryFnReturnType<TReturnType<T>>
+    >;
+};
+
+type TMutationFnReturnType<T> = T extends {
+  mutationFn: (...args: any) => Promise<infer U>;
+}
+  ? U
+  : never;
+
+type TMutationFnArgsType<T> = T extends {
+  mutationFn: (args: infer U) => any;
+}
+  ? U
+  : never;
+
+export const mutationHookFromMutation = <T extends (...args: any) => any>(
+  mutationFnCreator: T,
+) => {
+  return () =>
+    useMutation(mutationFnCreator()) as UseMutationResult<
+      TMutationFnReturnType<TReturnType<T>>,
+      unknown,
+      TMutationFnArgsType<TReturnType<T>>
+    >;
 };


### PR DESCRIPTION
This PR introduces:

1. Introduction of queryHookFromQuery and mutationHookFromMutation functions, which accept query or mutation functions and yield the corresponding hook functions.
2. Tests for `queryHookFromQuery` and `mutationHookFromMutation` functions.

Note: Separate tests for the hooks are unnecessary, as they function identical to their original query or mutation functions. As a proof of concept, I have substituted the query or mutation function with the corresponding hook in the `get` and `add` actions for the content API.