### PR TITLE
POC for documentation using typedoc and sphinx-js

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,8 @@
+sphinx-js==3.2.1
+sphinx-copybutton==0.5.2
+sphinx-book-theme==1.0.1
+sphinx-copybutton==0.5.2
+sphinx-design==0.5.0
+sphinx-sitemap==2.5.1
+sphinx-togglebutton==0.3.2
+sphinxext-opengraph==0.8.2

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,7 +63,16 @@ extensions = [
     "sphinx_design",
     "sphinx_sitemap",
     "sphinxext.opengraph",
+    "sphinx_js"
 ]
+
+primary_domain = 'js'
+
+js_language = 'typescript'
+
+js_source_path = '../src/restapi'
+
+jsdoc_config_path = '../typedoc.conf.json'
 
 # For more information see:
 # https://myst-parser.readthedocs.io/en/latest/syntax/optional.html

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -72,3 +72,8 @@ const { useGetContent } = client;
 
 const { data, isLoading } = useGetContent({ path: pathname });
 ```
+
+.. autofunction:: getContentQuery
+.. autofunction:: createContentMutation
+.. autofunction:: updateContentMutation
+.. autofunction:: deleteContentMutation

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ sphinx-design
 sphinx-sitemap
 sphinx-togglebutton
 sphinxext-opengraph
+sphinx-js

--- a/src/restapi/content/add.ts
+++ b/src/restapi/content/add.ts
@@ -35,6 +35,13 @@ export const createContent = async ({
   return apiRequest('post', validatedArgs.path, options);
 };
 
+/**
+ * Use the createContentMutation function to get the mutation for adding content at a given path.
+ *
+ * @param path
+ * @param data
+ * @returns details about the created content
+ */
 export const createContentMutation = ({
   config,
 }: {

--- a/src/restapi/content/delete.ts
+++ b/src/restapi/content/delete.ts
@@ -27,6 +27,12 @@ export const deleteContent = async ({
   return apiRequest('delete', validatedArgs.path, options);
 };
 
+/**
+ * Use the deleteContentMutation function to get the mutation for deleting content at a given path.
+ *
+ * @param path
+ * @returns undefined
+ */
 export const deleteContentMutation = ({
   config,
 }: {

--- a/src/restapi/content/get.ts
+++ b/src/restapi/content/get.ts
@@ -57,6 +57,16 @@ export const getContent = async ({
   return apiRequest('get', path, options);
 };
 
+/**
+ * Use the getContentQuery function to get the query for fetching the content at a given path.
+ *
+ * @param path
+ * @param version
+ * @param page
+ * @param fullObjects
+ * @param expand
+ * @returns details about the content at the given path
+ */
 export const getContentQuery = ({
   path,
   version,

--- a/src/restapi/content/update.ts
+++ b/src/restapi/content/update.ts
@@ -35,6 +35,13 @@ export const updateContent = async ({
   return apiRequest('patch', validatedArgs.path, options);
 };
 
+/**
+ * Use the updateContentMutation function to get the mutation for updating content at a given path.
+ *
+ * @param path
+ * @param data
+ * @returns details about the updated content
+ */
 export const updateContentMutation = ({
   config,
 }: {

--- a/typedoc.conf.json
+++ b/typedoc.conf.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite", "vitest/globals"]
+  },
+  "entryPoints": ["src"],
+  "excludePrivate": true,
+  "excludeExternals": true,
+  "readme": "none",
+  "excludeInternal": true,
+  "exclude": [
+    "node_modules",
+    "lib",
+    "lib64"
+  ]
+}


### PR DESCRIPTION
This POC uses typedoc and sphinx-js to generate documentation.

We need to specify the version of sphinx related packages in the constraints file because when the versions are not specified sphinx-js 1.0 is auto-installed, which is far older than the latest version 3.2.1, and lacks many of the features.

Sphinx-js supports a super old typedoc version 0.15.0 officially at least and I encountered another typedoc problem related to type errors reported in node_modules (which doesn't work even with `--skipLibCheck` for some reason) as well in my POC.

I think we can get it to work but it will require significant amount of time to debug and fix. Even then we might face issues with using latest typescript and typedoc. Perhaps it's better to just use latest typedoc with something like docusaurous?"